### PR TITLE
CLOUD-859 ability to override/add both global and host group level bl…

### DIFF
--- a/src/test/resources/blueprint-config.json
+++ b/src/test/resources/blueprint-config.json
@@ -7,13 +7,17 @@
     "configurations": [
         {
             "yarn-site": {
-                "property-key": "property-value",
-                "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+                "properties": {
+                    "property-key": "property-value",
+                    "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+                }
             }
         },
         {
             "hdfs-site": {
-                "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+                "properties": {
+                    "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+                }
             }
         }
     ],

--- a/src/test/resources/hdp-streaming-modified.json
+++ b/src/test/resources/hdp-streaming-modified.json
@@ -1,0 +1,1759 @@
+{
+  "Blueprints": {
+    "blueprint_name": "hdp-streaming-cluster",
+    "stack_version": "2.2",
+    "stack_name": "HDP"
+  },
+  "configurations": [
+    {
+      "ams-env": {
+        "properties": {
+          "content": "\n# Set environment variables here.\n\n# The java implementation to use. Java 1.6 required.\nexport JAVA_HOME={{java64_home}}\n\n# Collector Log directory for log4j\nexport AMS_COLLECTOR_LOG_DIR={{ams_collector_log_dir}}\n\n# Monitor Log directory for outfile\nexport AMS_MONITOR_LOG_DIR={{ams_monitor_log_dir}}\n\n# Collector pid directory\nexport AMS_COLLECTOR_PID_DIR={{ams_collector_pid_dir}}\n\n# Monitor pid directory\nexport AMS_MONITOR_PID_DIR={{ams_monitor_pid_dir}}\n\n# AMS HBase pid directory\nexport AMS_HBASE_PID_DIR={{hbase_pid_dir}}\n\n# AMS Collector heapsize\nexport AMS_COLLECTOR_HEAPSIZE={{metrics_collector_heapsize}}\n\n# AMS Collector options\nexport AMS_COLLECTOR_OPTS=\"-Djava.library.path=/usr/lib/ams-hbase/lib/hadoop-native -Xmx$AMS_COLLECTOR_HEAPSIZE \"\n{% if security_enabled %}\nexport AMS_COLLECTOR_OPTS=\"$AMS_COLLECTOR_OPTS -Djava.security.auth.login.config={{ams_collector_jaas_config_file}}\"\n{% endif %}",
+          "metrics_monitor_log_dir": "/var/log/ambari-metrics-monitor",
+          "ambari_metrics_user": "ams",
+          "metrics_collector_heapsize": "512m",
+          "metrics_collector_log_dir": "/var/log/ambari-metrics-collector",
+          "metrics_monitor_pid_dir": "/var/run/ambari-metrics-monitor",
+          "metrics_collector_pid_dir": "/var/run/ambari-metrics-collector"
+        }
+      }
+    },
+    {
+      "ams-hbase-env": {
+        "properties": {
+          "content": "\n# Set environment variables here.\n\n# The java implementation to use. Java 1.6 required.\nexport JAVA_HOME={{java64_home}}\n\n# HBase Configuration directory\nexport HBASE_CONF_DIR=${HBASE_CONF_DIR:-{{hbase_conf_dir}}}\n\n# Extra Java CLASSPATH elements. Optional.\nexport HBASE_CLASSPATH=${HBASE_CLASSPATH}\n\n# The maximum amount of heap to use, in MB. Default is 1000. Master heap size.\nexport HBASE_HEAPSIZE={{hbase_heapsize}}\n\n# Extra Java runtime options.\n# Below are what we set by default. May only work with SUN JVM.\n# For more on why as well as other possible settings,\n# see http://wiki.apache.org/hadoop/PerformanceTuning\nexport HBASE_OPTS=\"-XX:+UseConcMarkSweepGC -XX:ErrorFile={{hbase_log_dir}}/hs_err_pid%p.log -Djava.io.tmpdir={{hbase_tmp_dir}}\"\nexport SERVER_GC_OPTS=\"-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:{{hbase_log_dir}}/gc.log-`date +'%Y%m%d%H%M'`\"\n# Uncomment below to enable java garbage collection logging.\n# export HBASE_OPTS=\"$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$HBASE_HOME/logs/gc-hbase.log\"\n\n# Uncomment and adjust to enable JMX exporting\n# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.\n# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html\n#\n# export HBASE_JMX_BASE=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\"\nexport HBASE_MASTER_OPTS=\" -XX:PermSize=64m -XX:MaxPermSize={{hbase_master_maxperm_size}} -Xms{{hbase_heapsize}} -Xmx{{hbase_heapsize}} -Xmn{{hbase_master_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly\"\nexport HBASE_REGIONSERVER_OPTS=\"-XX:MaxPermSize=128m -Xmn{{regionserver_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -Xms{{regionserver_heapsize}} -Xmx{{regionserver_heapsize}}\"\n# export HBASE_THRIFT_OPTS=\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103\"\n# export HBASE_ZOOKEEPER_OPTS=\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104\"\n\n# File naming hosts on which HRegionServers will run. $HBASE_HOME/conf/regionservers by default.\nexport HBASE_REGIONSERVERS=${HBASE_CONF_DIR}/regionservers\n\n# Extra ssh options. Empty by default.\n# export HBASE_SSH_OPTS=\"-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR\"\n\n# Where log files are stored. $HBASE_HOME/logs by default.\nexport HBASE_LOG_DIR={{hbase_log_dir}}\n\n# A string representing this instance of hbase. $USER by default.\n# export HBASE_IDENT_STRING=$USER\n\n# The scheduling priority for daemon processes. See 'man nice'.\n# export HBASE_NICENESS=10\n\n# The directory where pid files are stored. /tmp by default.\nexport HBASE_PID_DIR={{hbase_pid_dir}}\n\n# Seconds to sleep between slave commands. Unset by default. This\n# can be useful in large clusters, where, e.g., slave rsyncs can\n# otherwise arrive faster than the master can service them.\n# export HBASE_SLAVE_SLEEP=0.1\n\n# Tell HBase whether it should manage it's own instance of Zookeeper or not.\nexport HBASE_MANAGES_ZK=false\n\n{% if security_enabled %}\nexport HBASE_OPTS=\"$HBASE_OPTS -Djava.security.auth.login.config={{client_jaas_config_file}}\"\nexport HBASE_MASTER_OPTS=\"$HBASE_MASTER_OPTS -Djava.security.auth.login.config={{master_jaas_config_file}}\"\nexport HBASE_REGIONSERVER_OPTS=\"$HBASE_REGIONSERVER_OPTS -Djava.security.auth.login.config={{regionserver_jaas_config_file}}\"\nexport HBASE_ZOOKEEPER_OPTS=\"$HBASE_ZOOKEEPER_OPTS -Djava.security.auth.login.config={{ams_zookeeper_jaas_config_file}}\"\n{% endif %}\n\n# use embedded native libs\n_HADOOP_NATIVE_LIB=\"/usr/lib/ams-hbase/lib/hadoop-native/\"\nexport HBASE_OPTS=\"$HBASE_OPTS -Djava.library.path=${_HADOOP_NATIVE_LIB}\"\n\n# Unset HADOOP_HOME to avoid importing HADOOP installed cluster related configs like: /usr/hdp/2.2.0.0-2041/hadoop/conf/\nexport HADOOP_HOME={{ams_hbase_home_dir}}",
+          "hbase_master_maxperm_size": "128m",
+          "hbase_pid_dir": "/var/run/ambari-metrics-collector/",
+          "regionserver_xmn_size": "256m",
+          "hbase_master_heapsize": "1024m",
+          "hbase_regionserver_heapsize": "1024m",
+          "hbase_regionserver_xmn_max": "512m",
+          "hbase_log_dir": "/var/log/ambari-metrics-collector",
+          "hbase_regionserver_xmn_ratio": "0.2",
+          "hbase_master_xmn_size": "128m"
+        }
+      }
+    },
+    {
+      "ams-hbase-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n\n# Define some default values that can be overridden by system properties\nhbase.root.logger=INFO,console\nhbase.security.logger=INFO,console\nhbase.log.dir=.\nhbase.log.file=hbase.log\n\n# Define the root logger to the system property \"hbase.root.logger\".\nlog4j.rootLogger=${hbase.root.logger}\n\n# Logging Threshold\nlog4j.threshold=ALL\n\n#\n# Daily Rolling File Appender\n#\nlog4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFA.File=${hbase.log.dir}/${hbase.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern=.yyyy-MM-dd\n\n# 30-day backup\n#log4j.appender.DRFA.MaxBackupIndex=30\nlog4j.appender.DRFA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\nlog4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n# Rolling File Appender properties\nhbase.log.maxfilesize=256MB\nhbase.log.maxbackupindex=20\n\n# Rolling File Appender\nlog4j.appender.RFA=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFA.File=${hbase.log.dir}/${hbase.log.file}\n\nlog4j.appender.RFA.MaxFileSize=${hbase.log.maxfilesize}\nlog4j.appender.RFA.MaxBackupIndex=${hbase.log.maxbackupindex}\n\nlog4j.appender.RFA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n#\n# Security audit appender\n#\nhbase.security.log.file=SecurityAuth.audit\nhbase.security.log.maxfilesize=256MB\nhbase.security.log.maxbackupindex=20\nlog4j.appender.RFAS=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFAS.File=${hbase.log.dir}/${hbase.security.log.file}\nlog4j.appender.RFAS.MaxFileSize=${hbase.security.log.maxfilesize}\nlog4j.appender.RFAS.MaxBackupIndex=${hbase.security.log.maxbackupindex}\nlog4j.appender.RFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.category.SecurityLogger=${hbase.security.logger}\nlog4j.additivity.SecurityLogger=false\n#log4j.logger.SecurityLogger.org.apache.hadoop.hbase.security.access.AccessController=TRACE\n\n#\n# Null Appender\n#\nlog4j.appender.NullAppender=org.apache.log4j.varia.NullAppender\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n# Custom Logging levels\n\nlog4j.logger.org.apache.zookeeper=INFO\n#log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG\nlog4j.logger.org.apache.hadoop.hbase=INFO\n# Make these two classes INFO-level. Make them DEBUG to see more zk debug.\nlog4j.logger.org.apache.hadoop.hbase.zookeeper.ZKUtil=INFO\nlog4j.logger.org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher=INFO\n#log4j.logger.org.apache.hadoop.dfs=DEBUG\n# Set this class to log INFO only otherwise its OTT\n# Enable this to get detailed connection error/retry logging.\n# log4j.logger.org.apache.hadoop.hbase.client.HConnectionManager$HConnectionImplementation=TRACE\n\n\n# Uncomment this line to enable tracing on _every_ RPC call (this can be a lot of output)\n#log4j.logger.org.apache.hadoop.ipc.HBaseServer.trace=DEBUG\n\n# Uncomment the below if you want to remove logging of client region caching'\n# and scan of .META. messages\n# log4j.logger.org.apache.hadoop.hbase.client.HConnectionManager$HConnectionImplementation=INFO\n# log4j.logger.org.apache.hadoop.hbase.client.MetaScanner=INFO"
+        }
+      }
+    },
+    {
+      "ams-hbase-policy": {
+        "properties": {
+          "security.client.protocol.acl": "*",
+          "security.admin.protocol.acl": "*",
+          "security.masterregion.protocol.acl": "*"
+        }
+      }
+    },
+    {
+      "ams-hbase-security-site": {
+        "properties": {
+          "hbase.zookeeper.property.kerberos.removeHostFromPrincipal": "",
+          "hbase.regionserver.kerberos.principal": "",
+          "hbase.zookeeper.property.authProvider.1": "",
+          "hbase.coprocessor.master.classes": "",
+          "hbase.zookeeper.property.kerberos.removeRealmFromPrincipal": "",
+          "hbase.security.authorization": "",
+          "zookeeper.znode.parent": "",
+          "ams.zookeeper.keytab": "",
+          "hbase.myclient.principal": "",
+          "hbase.security.authentication": "",
+          "hbase.master.kerberos.principal": "",
+          "hadoop.security.authentication": "",
+          "hbase.coprocessor.region.classes": "",
+          "hbase.master.keytab.file": "",
+          "hbase.zookeeper.property.jaasLoginRenew": "",
+          "ams.zookeeper.principal": "",
+          "hbase.myclient.keytab": "",
+          "hbase.regionserver.keytab.file": ""
+        }
+      }
+    },
+    {
+      "ams-hbase-site": {
+        "properties": {
+          "hbase.hregion.memstore.flush.size": "134217728",
+          "phoenix.sequence.saltBuckets": "2",
+          "hbase.client.scanner.timeout.period": "900000",
+          "hbase.master.info.bindAddress": "0.0.0.0",
+          "hbase.local.dir": "${hbase.tmp.dir}/local",
+          "hbase.hstore.flusher.count": "2",
+          "hbase.master.port": "61300",
+          "hbase.regionserver.global.memstore.upperLimit": "0.35",
+          "hbase.hregion.majorcompaction": "0",
+          "hbase.zookeeper.leaderport": "61388",
+          "hbase.client.scanner.caching": "10000",
+          "hbase.master.info.port": "61310",
+          "hbase.regionserver.port": "61320",
+          "phoenix.query.spoolThresholdBytes": "12582912",
+          "hbase.cluster.distributed": "false",
+          "hbase.rootdir": "file:///var/lib/ambari-metrics-collector/hbase",
+          "phoenix.query.maxGlobalMemoryPercentage": "15",
+          "phoenix.query.timeoutMs": "1200000",
+          "hbase.regionserver.info.port": "61330",
+          "zookeeper.session.timeout.localHBaseCluster": "20000",
+          "hbase.regionserver.global.memstore.lowerLimit": "0.3",
+          "hbase.replication": "false",
+          "hbase.zookeeper.peerport": "61288",
+          "hbase.tmp.dir": "/var/lib/ambari-metrics-collector/hbase-tmp",
+          "hbase.regionserver.thread.compaction.small": "3",
+          "phoenix.groupby.maxCacheSize": "307200000",
+          "hbase.master.wait.on.regionservers.mintostart": "1",
+          "hbase.zookeeper.property.dataDir": "${hbase.tmp.dir}/zookeeper",
+          "hbase.hstore.blockingStoreFiles": "200",
+          "hbase.snapshot.enabled": "false",
+          "hfile.block.cache.size": "0.3",
+          "hbase.hregion.memstore.block.multiplier": "4",
+          "zookeeper.session.timeout": "120000",
+          "hbase.zookeeper.property.clientPort": "61181",
+          "hbase.regionserver.thread.compaction.large": "2",
+          "phoenix.spool.directory": "${hbase.tmp.dir}/phoenix-spool",
+          "hbase.zookeeper.quorum": "{{zookeeper_quorum_hosts}}"
+        }
+      }
+    },
+    {
+      "ams-log4j": {
+        "properties": {
+          "content": "\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n\n# Define some default values that can be overridden by system properties\nams.log.dir=.\nams.log.file=ambari-metrics-collector.log\n\n# Root logger option\nlog4j.rootLogger=INFO,file\n\n# Direct log messages to a log file\nlog4j.appender.file=org.apache.log4j.RollingFileAppender\nlog4j.appender.file.File=${ams.log.dir}/${ams.log.file}\nlog4j.appender.file.MaxFileSize=80MB\nlog4j.appender.file.MaxBackupIndex=60\nlog4j.appender.file.layout=org.apache.log4j.PatternLayout\nlog4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p [%t] %c{1}:%L - %m%n"
+        }
+      }
+    },
+    {
+      "ams-site": {
+        "properties": {
+          "timeline.metrics.host.aggregator.minute.checkpointCutOffMultiplier": "2",
+          "timeline.metrics.host.aggregator.hourly.checkpointCutOffMultiplier": "2",
+          "timeline.metrics.cluster.aggregator.hourly.ttl": "31536000",
+          "timeline.metrics.service.webapp.address": "0.0.0.0:6188",
+          "timeline.metrics.service.rpc.address": "0.0.0.0:60200",
+          "timeline.metrics.cluster.aggregator.hourly.interval": "3600",
+          "timeline.metrics.cluster.aggregator.hourly.checkpointCutOffMultiplier": "2",
+          "timeline.metrics.hbase.compression.scheme": "SNAPPY",
+          "timeline.metrics.host.aggregator.hourly.ttl": "2592000",
+          "timeline.metrics.host.aggregator.hourly.disabled": "false",
+          "timeline.metrics.aggregator.checkpoint.dir": "/var/lib/ambari-metrics-collector/checkpoint",
+          "timeline.metrics.cluster.aggregator.minute.disabled": "false",
+          "timeline.metrics.service.operation.mode": "embedded",
+          "timeline.metrics.cluster.aggregator.minute.checkpointCutOffMultiplier": "2",
+          "timeline.metrics.host.aggregator.minute.interval": "120",
+          "timeline.metrics.host.aggregator.minute.ttl": "604800",
+          "phoenix.query.maxGlobalMemoryPercentage": "25",
+          "timeline.metrics.hbase.data.block.encoding": "FAST_DIFF",
+          "timeline.metrics.service.checkpointDelay": "60",
+          "timeline.metrics.cluster.aggregator.minute.timeslice.interval": "15",
+          "timeline.metrics.service.default.result.limit": "5760",
+          "timeline.metrics.cluster.aggregator.minute.interval": "120",
+          "timeline.metrics.host.aggregator.hourly.interval": "3600",
+          "timeline.metrics.cluster.aggregator.hourly.disabled": "false",
+          "timeline.metrics.host.aggregator.minute.disabled": "false",
+          "timeline.metrics.cluster.aggregator.minute.ttl": "2592000",
+          "timeline.metrics.service.resultset.fetchSize": "2000",
+          "timeline.metrics.host.aggregator.ttl": "86400",
+          "phoenix.spool.directory": "/tmp"
+        }
+      }
+    },
+    {
+      "capacity-scheduler": {
+        "properties": {
+          "yarn.scheduler.capacity.root.queues": "default",
+          "yarn.scheduler.capacity.root.default.acl_administer_jobs": "*",
+          "yarn.scheduler.capacity.resource-calculator": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator",
+          "yarn.scheduler.capacity.root.default.maximum-capacity": "100",
+          "yarn.scheduler.capacity.node-locality-delay": "40",
+          "yarn.scheduler.capacity.maximum-am-resource-percent": "0.2",
+          "yarn.scheduler.capacity.root.accessible-node-labels.default.maximum-capacity": "-1",
+          "yarn.scheduler.capacity.root.default.acl_submit_applications": "*",
+          "yarn.scheduler.capacity.root.default.state": "RUNNING",
+          "yarn.scheduler.capacity.root.accessible-node-labels": "*",
+          "yarn.scheduler.capacity.root.acl_administer_queue": "*",
+          "yarn.scheduler.capacity.maximum-applications": "10000",
+          "yarn.scheduler.capacity.root.default-node-label-expression": " ",
+          "yarn.scheduler.capacity.root.default.capacity": "100",
+          "yarn.scheduler.capacity.root.accessible-node-labels.default.capacity": "-1",
+          "yarn.scheduler.capacity.root.default.user-limit-factor": "1",
+          "yarn.scheduler.capacity.default.minimum-user-limit-percent": "100",
+          "yarn.scheduler.capacity.root.capacity": "100"
+        }
+      }
+    },
+    {
+      "cluster-env": {
+        "properties": {
+          "user_group": "hadoop",
+          "kerberos_domain": "EXAMPLE.COM",
+          "security_enabled": "false",
+          "hive_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/hive/",
+          "sqoop_tar_source": "/usr/hdp/current/sqoop-client/sqoop.tar.gz",
+          "hadoop-streaming_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/mapreduce/",
+          "pig_tar_source": "/usr/hdp/current/pig-client/pig.tar.gz",
+          "mapreduce_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/mapreduce/",
+          "hive_tar_source": "/usr/hdp/current/hive-client/hive.tar.gz",
+          "mapreduce_tar_source": "/usr/hdp/current/hadoop-client/mapreduce.tar.gz",
+          "pig_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/pig/",
+          "smokeuser": "ambari-qa",
+          "tez_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/tez/",
+          "hadoop-streaming_tar_source": "/usr/hdp/current/hadoop-mapreduce-client/hadoop-streaming.jar",
+          "smokeuser_keytab": "/etc/security/keytabs/smokeuser.headless.keytab",
+          "sqoop_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/sqoop/",
+          "tez_tar_source": "/usr/hdp/current/tez-client/lib/tez.tar.gz",
+          "ignore_groupsusers_create": "false"
+        }
+      }
+    },
+    {
+      "core-site": {
+        "properties_attributes": {
+          "final": {
+            "fs.defaultFS": "true"
+          }
+        },
+        "properties": {
+          "io.serializations": "org.apache.hadoop.io.serializer.WritableSerialization",
+          "hadoop.proxyuser.hive.hosts": "%HOSTGROUP::host_group_master_2%",
+          "io.file.buffer.size": "131072",
+          "hadoop.proxyuser.hcat.hosts": "%HOSTGROUP::host_group_master_2%",
+          "ipc.client.connection.maxidletime": "30000",
+          "hadoop.proxyuser.hive.groups": "users",
+          "hadoop.proxyuser.falcon.hosts": "*",
+          "io.compression.codecs": "org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.SnappyCodec",
+          "hadoop.http.authentication.simple.anonymous.allowed": "true",
+          "mapreduce.jobtracker.webinterface.trusted": "false",
+          "hadoop.proxyuser.oozie.groups": "*",
+          "fs.trash.interval": "360",
+          "ha.failover-controller.active-standby-elector.zk.op.retries": "120",
+          "hadoop.proxyuser.hcat.groups": "users",
+          "ipc.client.idlethreshold": "8000",
+          "hadoop.security.authentication": "simple",
+          "fs.defaultFS": "hdfs://%HOSTGROUP::host_group_master_1%:8020",
+          "ipc.server.tcpnodelay": "true",
+          "hadoop.security.auth_to_local": "\n        DEFAULT",
+          "proxyuser_group": "users",
+          "ipc.client.connect.max.retries": "50",
+          "hadoop.security.authorization": "false",
+          "hadoop.proxyuser.falcon.groups": "users",
+          "hadoop.proxyuser.oozie.hosts": "%HOSTGROUP::host_group_master_1%"
+        }
+      }
+    },
+    {
+      "falcon-env": {
+        "properties": {
+          "content": "\n# The java implementation to use. If JAVA_HOME is not found we expect java and jar to be in path\nexport JAVA_HOME={{java_home}}\n\n# any additional java opts you want to set. This will apply to both client and server operations\n#export FALCON_OPTS=\n\n# any additional java opts that you want to set for client only\n#export FALCON_CLIENT_OPTS=\n\n# java heap size we want to set for the client. Default is 1024MB\n#export FALCON_CLIENT_HEAP=\n\n# any additional opts you want to set for prisim service.\n#export FALCON_PRISM_OPTS=\n\n# java heap size we want to set for the prisim service. Default is 1024MB\n#export FALCON_PRISM_HEAP=\n\n# any additional opts you want to set for falcon service.\nexport FALCON_SERVER_OPTS=\"-Dfalcon.embeddedmq={{falcon_embeddedmq_enabled}} -Dfalcon.emeddedmq.port={{falcon_emeddedmq_port}}\"\n\n# java heap size we want to set for the falcon server. Default is 1024MB\n#export FALCON_SERVER_HEAP=\n\n# What is is considered as falcon home dir. Default is the base location of the installed software\n#export FALCON_HOME_DIR=\n\n# Where log files are stored. Defatult is logs directory under the base install location\nexport FALCON_LOG_DIR={{falcon_log_dir}}\n\n# Where pid files are stored. Defatult is logs directory under the base install location\nexport FALCON_PID_DIR={{falcon_pid_dir}}\n\n# where the falcon active mq data is stored. Defatult is logs/data directory under the base install location\nexport FALCON_DATA_DIR={{falcon_embeddedmq_data}}\n\n# Where do you want to expand the war file. By Default it is in /server/webapp dir under the base install dir.\n#export FALCON_EXPANDED_WEBAPP_DIR=",
+          "falcon.emeddedmq.port": "61616",
+          "falcon_port": "15000",
+          "falcon_store_uri": "file:///hadoop/falcon/store",
+          "falcon_log_dir": "/var/log/falcon",
+          "falcon.embeddedmq.data": "/hadoop/falcon/embeddedmq/data",
+          "falcon_local_dir": "/hadoop/falcon",
+          "falcon_pid_dir": "/var/run/falcon",
+          "falcon_user": "falcon",
+          "falcon.embeddedmq": "true"
+        }
+      }
+    },
+    {
+      "falcon-runtime.properties": {
+        "properties": {
+          "*.log.cleanup.frequency.days.retention": "days(7)",
+          "*.log.cleanup.frequency.minutes.retention": "hours(6)",
+          "*.log.cleanup.frequency.hours.retention": "minutes(1)",
+          "*.log.cleanup.frequency.months.retention": "months(3)",
+          "*.domain": "${falcon.app.type}"
+        }
+      }
+    },
+    {
+      "falcon-startup.properties": {
+        "properties": {
+          "*.config.store.uri": "file:///hadoop/falcon/store",
+          "*.falcon.security.authorization.admin.groups": "falcon",
+          "*.falcon.http.authentication.type": "simple",
+          "*.falcon.service.authentication.kerberos.keytab": "/etc/security/keytabs/falcon.service.keytab",
+          "*.max.retry.failure.count": "1",
+          "*.falcon.security.authorization.enabled": "false",
+          "*.entity.topic": "FALCON.ENTITY.TOPIC",
+          "*.falcon.graph.serialize.path": "/hadoopfs/fs1/falcon",
+          "prism.application.services": "org.apache.falcon.entity.store.ConfigurationStore",
+          "*.application.services": "org.apache.falcon.security.AuthenticationInitializationService,\\\n      org.apache.falcon.workflow.WorkflowJobEndNotificationService, \\\n      org.apache.falcon.service.ProcessSubscriberService,\\\n      org.apache.falcon.entity.store.ConfigurationStore,\\\n      org.apache.falcon.rerun.service.RetryService,\\\n      org.apache.falcon.rerun.service.LateRunService,\\\n      org.apache.falcon.service.LogCleanupService,\\\n      org.apache.falcon.metadata.MetadataMappingService",
+          "*.journal.impl": "org.apache.falcon.transaction.SharedFileSystemJournal",
+          "*.falcon.graph.preserve.history": "false",
+          "*.configstore.listeners": "org.apache.falcon.entity.v0.EntityGraph,\\\n      org.apache.falcon.entity.ColoClusterRelation,\\\n      org.apache.falcon.group.FeedGroupMap,\\\n      org.apache.falcon.service.SharedLibraryHostingService",
+          "*.falcon.http.authentication.kerberos.keytab": "/etc/security/keytabs/spnego.service.keytab",
+          "*.internal.queue.size": "1000",
+          "*.falcon.authentication.type": "simple",
+          "*.falcon.enableTLS": "false",
+          "*.falcon.security.authorization.provider": "org.apache.falcon.security.DefaultAuthorizationProvider",
+          "*.falcon.http.authentication.kerberos.name.rules": "DEFAULT",
+          "*.falcon.http.authentication.token.validity": "36000",
+          "*.system.lib.location": "${falcon.home}/server/webapp/${falcon.app.type}/WEB-INF/lib",
+          "*.falcon.graph.storage.directory": "/hadoopfs/fs1/falcon",
+          "*.retry.recorder.path": "${falcon.log.dir}/retry",
+          "*.falcon.http.authentication.blacklisted.users": "",
+          "*.falcon.http.authentication.cookie.domain": "EXAMPLE.COM",
+          "*.falcon.cleanup.service.frequency": "days(1)",
+          "*.falcon.security.authorization.admin.users": "falcon,ambari-qa",
+          "*.ProcessInstanceManager.impl": "org.apache.falcon.resource.InstanceManager",
+          "*.broker.ttlInMins": "4320",
+          "*.shared.libs": "activemq-core,ant,geronimo-j2ee-management,hadoop-distcp,jms,json-simple,oozie-client,spring-jms",
+          "*.oozie.process.workflow.builder": "org.apache.falcon.workflow.OozieProcessWorkflowBuilder",
+          "*.dfs.namenode.kerberos.principal": "nn/_HOST@EXAMPLE.COM",
+          "*.catalog.service.impl": "org.apache.falcon.catalog.HiveCatalogService",
+          "*.falcon.http.authentication.simple.anonymous.allowed": "true",
+          "*.ConfigSyncService.impl": "org.apache.falcon.resource.ConfigSyncService",
+          "*.domain": "${falcon.app.type}",
+          "*.broker.url": "tcp://%HOSTGROUP::host_group_master_1%:61616",
+          "*.oozie.feed.workflow.builder": "org.apache.falcon.workflow.OozieFeedWorkflowBuilder",
+          "*.falcon.graph.blueprints.graph": "com.thinkaurelius.titan.core.TitanFactory",
+          "*.broker.impl.class": "org.apache.activemq.ActiveMQConnectionFactory",
+          "*.falcon.graph.storage.backend": "berkeleyje",
+          "*.SchedulableEntityManager.impl": "org.apache.falcon.resource.SchedulableEntityManager",
+          "prism.configstore.listeners": "org.apache.falcon.entity.v0.EntityGraph,\\\n      org.apache.falcon.entity.ColoClusterRelation,\\\n      org.apache.falcon.group.FeedGroupMap",
+          "*.falcon.security.authorization.superusergroup": "falcon",
+          "*.falcon.http.authentication.signature.secret": "falcon",
+          "*.workflow.engine.impl": "org.apache.falcon.workflow.engine.OozieWorkflowEngine"
+        }
+      }
+    },
+    {
+      "flume-conf": {
+        "properties": {
+          "content": "\n# Flume agent config"
+        }
+      }
+    },
+    {
+      "flume-env": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one or more\n# contributor license agreements.  See the NOTICE file distributed with\n# this work for additional information regarding copyright ownership.\n# The ASF licenses this file to You under the Apache License, Version 2.0\n# (the \"License\"); you may not use this file except in compliance with\n# the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n# If this file is placed at FLUME_CONF_DIR/flume-env.sh, it will be sourced\n# during Flume startup.\n\n# Enviroment variables can be set here.\n\nexport JAVA_HOME={{java_home}}\n\n# Give Flume more memory and pre-allocate, enable remote monitoring via JMX\n# export JAVA_OPTS=\"-Xms100m -Xmx2000m -Dcom.sun.management.jmxremote\"\n\n# Note that the Flume conf directory is always included in the classpath.\n# Add flume sink to classpath\nif [ -e \"/usr/lib/flume/lib/ambari-metrics-flume-sink.jar\" ]; then\n  export FLUME_CLASSPATH=$FLUME_CLASSPATH:/usr/lib/flume/lib/ambari-metrics-flume-sink.jar\nfi\n\nexport HIVE_HOME={{flume_hive_home}}\nexport HCAT_HOME={{flume_hcat_home}}",
+          "flume_user": "flume",
+          "flume_log_dir": "/var/log/flume",
+          "flume_conf_dir": "/etc/flume/conf"
+        }
+      }
+    },
+    {
+      "gateway-log4j": {
+        "properties": {
+          "content": "\n\n      # Licensed to the Apache Software Foundation (ASF) under one\n      # or more contributor license agreements. See the NOTICE file\n      # distributed with this work for additional information\n      # regarding copyright ownership. The ASF licenses this file\n      # to you under the Apache License, Version 2.0 (the\n      # \"License\"); you may not use this file except in compliance\n      # with the License. You may obtain a copy of the License at\n      #\n      # http://www.apache.org/licenses/LICENSE-2.0\n      #\n      # Unless required by applicable law or agreed to in writing, software\n      # distributed under the License is distributed on an \"AS IS\" BASIS,\n      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n      # See the License for the specific language governing permissions and\n      # limitations under the License.\n\n      app.log.dir=${launcher.dir}/../logs\n      app.log.file=${launcher.name}.log\n      app.audit.file=${launcher.name}-audit.log\n\n      log4j.rootLogger=ERROR, drfa\n\n      log4j.logger.org.apache.hadoop.gateway=INFO\n      #log4j.logger.org.apache.hadoop.gateway=DEBUG\n\n      #log4j.logger.org.eclipse.jetty=DEBUG\n      #log4j.logger.org.apache.shiro=DEBUG\n      #log4j.logger.org.apache.http=DEBUG\n      #log4j.logger.org.apache.http.client=DEBUG\n      #log4j.logger.org.apache.http.headers=DEBUG\n      #log4j.logger.org.apache.http.wire=DEBUG\n\n      log4j.appender.stdout=org.apache.log4j.ConsoleAppender\n      log4j.appender.stdout.layout=org.apache.log4j.PatternLayout\n      log4j.appender.stdout.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\n\n      log4j.appender.drfa=org.apache.log4j.DailyRollingFileAppender\n      log4j.appender.drfa.File=${app.log.dir}/${app.log.file}\n      log4j.appender.drfa.DatePattern=.yyyy-MM-dd\n      log4j.appender.drfa.layout=org.apache.log4j.PatternLayout\n      log4j.appender.drfa.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n      log4j.logger.audit=INFO, auditfile\n      log4j.appender.auditfile=org.apache.log4j.DailyRollingFileAppender\n      log4j.appender.auditfile.File=${app.log.dir}/${app.audit.file}\n      log4j.appender.auditfile.Append = true\n      log4j.appender.auditfile.DatePattern = '.'yyyy-MM-dd\n      log4j.appender.auditfile.layout = org.apache.hadoop.gateway.audit.log4j.layout.AuditLayout"
+        }
+      }
+    },
+    {
+      "gateway-site": {
+        "properties": {
+          "sun.security.krb5.debug": "true",
+          "gateway.hadoop.kerberos.secured": "false",
+          "gateway.path": "gateway",
+          "gateway.gateway.conf.dir": "deployments",
+          "java.security.auth.login.config": "/etc/knox/conf/krb5JAASLogin.conf",
+          "java.security.krb5.conf": "/etc/knox/conf/krb5.conf",
+          "gateway.port": "8443"
+        }
+      }
+    },
+    {
+      "hadoop-env": {
+        "properties": {
+          "namenode_opt_permsize": "128m",
+          "hadoop_heapsize": "1024",
+          "namenode_opt_maxnewsize": "256m",
+          "namenode_heapsize": "1024m",
+          "dfs.datanode.data.dir.mount.file": "/etc/hadoop/conf/dfs_data_dir_mount.hist",
+          "content": "\n# Set Hadoop-specific environment variables here.\n\n# The only required environment variable is JAVA_HOME.  All others are\n# optional.  When running a distributed configuration it is best to\n# set JAVA_HOME in this file, so that it is correctly defined on\n# remote nodes.\n\n# The java implementation to use.  Required.\nexport JAVA_HOME={{java_home}}\nexport HADOOP_HOME_WARN_SUPPRESS=1\n\n# Hadoop home directory\nexport HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\n# Hadoop Configuration Directory\n\n{# this is different for HDP1 #}\n# Path to jsvc required by secure HDP 2.0 datanode\nexport JSVC_HOME={{jsvc_path}}\n\n\n# The maximum amount of heap to use, in MB. Default is 1000.\nexport HADOOP_HEAPSIZE=\"{{hadoop_heapsize}}\"\n\nexport HADOOP_NAMENODE_INIT_HEAPSIZE=\"-Xms{{namenode_heapsize}}\"\n\n# Extra Java runtime options.  Empty by default.\nexport HADOOP_OPTS=\"-Djava.net.preferIPv4Stack=true ${HADOOP_OPTS}\"\n\n# Command specific options appended to HADOOP_OPTS when specified\nexport HADOOP_NAMENODE_OPTS=\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{namenode_opt_newsize}} -XX:MaxNewSize={{namenode_opt_maxnewsize}} -XX:PermSize={{namenode_opt_permsize}} -XX:MaxPermSize={{namenode_opt_maxpermsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xms{{namenode_heapsize}} -Xmx{{namenode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT ${HADOOP_NAMENODE_OPTS}\"\nHADOOP_JOBTRACKER_OPTS=\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{jtnode_opt_newsize}} -XX:MaxNewSize={{jtnode_opt_maxnewsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xmx{{jtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dmapred.audit.logger=INFO,MRAUDIT -Dhadoop.mapreduce.jobsummary.logger=INFO,JSA ${HADOOP_JOBTRACKER_OPTS}\"\n\nHADOOP_TASKTRACKER_OPTS=\"-server -Xmx{{ttnode_heapsize}} -Dhadoop.security.logger=ERROR,console -Dmapred.audit.logger=ERROR,console ${HADOOP_TASKTRACKER_OPTS}\"\nexport HADOOP_DATANODE_OPTS=\"-server -XX:ParallelGCThreads=4 -XX:+UseConcMarkSweepGC -XX:ErrorFile=/var/log/hadoop/$USER/hs_err_pid%p.log -XX:NewSize=200m -XX:MaxNewSize=200m -XX:PermSize=128m -XX:MaxPermSize=256m -Xloggc:/var/log/hadoop/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xms{{dtnode_heapsize}} -Xmx{{dtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT ${HADOOP_DATANODE_OPTS}\"\nHADOOP_BALANCER_OPTS=\"-server -Xmx{{hadoop_heapsize}}m ${HADOOP_BALANCER_OPTS}\"\n\nexport HADOOP_SECONDARYNAMENODE_OPTS=$HADOOP_NAMENODE_OPTS\n\n# The following applies to multiple commands (fs, dfs, fsck, distcp etc)\nexport HADOOP_CLIENT_OPTS=\"-Xmx${HADOOP_HEAPSIZE}m -XX:MaxPermSize=512m $HADOOP_CLIENT_OPTS\"\n\n# On secure datanodes, user to run the datanode as after dropping privileges\nexport HADOOP_SECURE_DN_USER=${HADOOP_SECURE_DN_USER:-{{hadoop_secure_dn_user}}}\n\n# Extra ssh options.  Empty by default.\nexport HADOOP_SSH_OPTS=\"-o ConnectTimeout=5 -o SendEnv=HADOOP_CONF_DIR\"\n\n# Where log files are stored.  $HADOOP_HOME/logs by default.\nexport HADOOP_LOG_DIR={{hdfs_log_dir_prefix}}/$USER\n\n# History server logs\nexport HADOOP_MAPRED_LOG_DIR={{mapred_log_dir_prefix}}/$USER\n\n# Where log files are stored in the secure data environment.\nexport HADOOP_SECURE_DN_LOG_DIR={{hdfs_log_dir_prefix}}/$HADOOP_SECURE_DN_USER\n\n# File naming remote slave hosts.  $HADOOP_HOME/conf/slaves by default.\n# export HADOOP_SLAVES=${HADOOP_HOME}/conf/slaves\n\n# host:path where hadoop code should be rsync'd from.  Unset by default.\n# export HADOOP_MASTER=master:/home/$USER/src/hadoop\n\n# Seconds to sleep between slave commands.  Unset by default.  This\n# can be useful in large clusters, where, e.g., slave rsyncs can\n# otherwise arrive faster than the master can service them.\n# export HADOOP_SLAVE_SLEEP=0.1\n\n# The directory where pid files are stored. /tmp by default.\nexport HADOOP_PID_DIR={{hadoop_pid_dir_prefix}}/$USER\nexport HADOOP_SECURE_DN_PID_DIR={{hadoop_pid_dir_prefix}}/$HADOOP_SECURE_DN_USER\n\n# History server pid\nexport HADOOP_MAPRED_PID_DIR={{mapred_pid_dir_prefix}}/$USER\n\nYARN_RESOURCEMANAGER_OPTS=\"-Dyarn.server.resourcemanager.appsummary.logger=INFO,RMSUMMARY\"\n\n# A string representing this instance of hadoop. $USER by default.\nexport HADOOP_IDENT_STRING=$USER\n\n# The scheduling priority for daemon processes.  See 'man nice'.\n\n# export HADOOP_NICENESS=10\n\n# Use libraries from standard classpath\nJAVA_JDBC_LIBS=\"\"\n#Add libraries required by mysql connector\nfor jarFile in `ls /usr/share/java/*mysql* 2>/dev/null`\ndo\n  JAVA_JDBC_LIBS=${JAVA_JDBC_LIBS}:$jarFile\ndone\n# Add libraries required by oracle connector\nfor jarFile in `ls /usr/share/java/*ojdbc* 2>/dev/null`\ndo\n  JAVA_JDBC_LIBS=${JAVA_JDBC_LIBS}:$jarFile\ndone\n# Add libraries required by nodemanager\nMAPREDUCE_LIBS={{mapreduce_libs_path}}\nexport HADOOP_CLASSPATH=${HADOOP_CLASSPATH}${JAVA_JDBC_LIBS}:${MAPREDUCE_LIBS}\n\n# added to the HADOOP_CLASSPATH\nif [ -d \"/usr/hdp/current/tez-client\" ]; then\n  if [ -d \"/etc/tez/conf/\" ]; then\n    # When using versioned RPMs, the tez-client will be a symlink to the current folder of tez in HDP.\n    export HADOOP_CLASSPATH=${HADOOP_CLASSPATH}:/usr/hdp/current/tez-client/*:/usr/hdp/current/tez-client/lib/*:/etc/tez/conf/\n  fi\nfi\n\n\n# Setting path to hdfs command line\nexport HADOOP_LIBEXEC_DIR={{hadoop_libexec_dir}}\n\n# Mostly required for hadoop 2.0\nexport JAVA_LIBRARY_PATH=${JAVA_LIBRARY_PATH}\n\nexport HADOOP_OPTS=\"-Dhdp.version=$HDP_VERSION $HADOOP_OPTS\"",
+          "namenode_opt_newsize": "256m",
+          "dtnode_heapsize": "1024m",
+          "hdfs_user": "hdfs",
+          "namenode_opt_maxpermsize": "256m",
+          "hadoop_pid_dir_prefix": "/var/run/hadoop",
+          "hdfs_log_dir_prefix": "/var/log/hadoop",
+          "hadoop_root_logger": "INFO,RFA",
+          "proxyuser_group": "users"
+        }
+      }
+    },
+    {
+      "hadoop-policy": {
+        "properties": {
+          "security.client.protocol.acl": "*",
+          "security.job.client.protocol.acl": "*",
+          "security.inter.datanode.protocol.acl": "*",
+          "security.admin.operations.protocol.acl": "hadoop",
+          "security.client.datanode.protocol.acl": "*",
+          "security.job.task.protocol.acl": "*",
+          "security.refresh.usertogroups.mappings.protocol.acl": "hadoop",
+          "security.refresh.policy.protocol.acl": "hadoop",
+          "security.namenode.protocol.acl": "*",
+          "security.datanode.protocol.acl": "*",
+          "security.inter.tracker.protocol.acl": "*"
+        }
+      }
+    },
+    {
+      "hbase-env": {
+        "properties": {
+          "content": "\n# Set environment variables here.\n\n# The java implementation to use. Java 1.6 required.\nexport JAVA_HOME={{java64_home}}\n\n# HBase Configuration directory\nexport HBASE_CONF_DIR=${HBASE_CONF_DIR:-{{hbase_conf_dir}}}\n\n# Extra Java CLASSPATH elements. Optional.\nexport HBASE_CLASSPATH=${HBASE_CLASSPATH}\n\n\n# The maximum amount of heap to use, in MB. Default is 1000.\n# export HBASE_HEAPSIZE=1000\n\n# Extra Java runtime options.\n# Below are what we set by default. May only work with SUN JVM.\n# For more on why as well as other possible settings,\n# see http://wiki.apache.org/hadoop/PerformanceTuning\nexport SERVER_GC_OPTS=\"-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:{{log_dir}}/gc.log-`date +'%Y%m%d%H%M'`\"\n# Uncomment below to enable java garbage collection logging.\n# export HBASE_OPTS=\"$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$HBASE_HOME/logs/gc-hbase.log\"\n\n# Uncomment and adjust to enable JMX exporting\n# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.\n# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html\n#\n# export HBASE_JMX_BASE=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\"\n# If you want to configure BucketCache, specify '-XX: MaxDirectMemorySize=' with proper direct memory size\n# export HBASE_THRIFT_OPTS=\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103\"\n# export HBASE_ZOOKEEPER_OPTS=\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104\"\n\n# File naming hosts on which HRegionServers will run. $HBASE_HOME/conf/regionservers by default.\nexport HBASE_REGIONSERVERS=${HBASE_CONF_DIR}/regionservers\n\n# Extra ssh options. Empty by default.\n# export HBASE_SSH_OPTS=\"-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR\"\n\n# Where log files are stored. $HBASE_HOME/logs by default.\nexport HBASE_LOG_DIR={{log_dir}}\n\n# A string representing this instance of hbase. $USER by default.\n# export HBASE_IDENT_STRING=$USER\n\n# The scheduling priority for daemon processes. See 'man nice'.\n# export HBASE_NICENESS=10\n\n# The directory where pid files are stored. /tmp by default.\nexport HBASE_PID_DIR={{pid_dir}}\n\n# Seconds to sleep between slave commands. Unset by default. This\n# can be useful in large clusters, where, e.g., slave rsyncs can\n# otherwise arrive faster than the master can service them.\n# export HBASE_SLAVE_SLEEP=0.1\n\n# Tell HBase whether it should manage it's own instance of Zookeeper or not.\nexport HBASE_MANAGES_ZK=false\n\n{% if security_enabled %}\nexport HBASE_OPTS=\"$HBASE_OPTS -XX:+UseConcMarkSweepGC -XX:ErrorFile={{log_dir}}/hs_err_pid%p.log -Djava.security.auth.login.config={{client_jaas_config_file}}\"\nexport HBASE_MASTER_OPTS=\"$HBASE_MASTER_OPTS -Xmx{{master_heapsize}} -Djava.security.auth.login.config={{master_jaas_config_file}}\"\nexport HBASE_REGIONSERVER_OPTS=\"$HBASE_REGIONSERVER_OPTS -Xmn{{regionserver_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70  -Xms{{regionserver_heapsize}} -Xmx{{regionserver_heapsize}} -Djava.security.auth.login.config={{regionserver_jaas_config_file}}\"\n{% else %}\nexport HBASE_OPTS=\"$HBASE_OPTS -XX:+UseConcMarkSweepGC -XX:ErrorFile={{log_dir}}/hs_err_pid%p.log\"\nexport HBASE_MASTER_OPTS=\"$HBASE_MASTER_OPTS -Xmx{{master_heapsize}}\"\nexport HBASE_REGIONSERVER_OPTS=\"$HBASE_REGIONSERVER_OPTS -Xmn{{regionserver_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70  -Xms{{regionserver_heapsize}} -Xmx{{regionserver_heapsize}}\"\n{% endif %}",
+          "hbase_pid_dir": "/var/run/hbase",
+          "hbase_master_heapsize": "1024m",
+          "hbase_user": "hbase",
+          "hbase_regionserver_heapsize": "1024m",
+          "hbase_regionserver_xmn_max": "512",
+          "hbase_log_dir": "/var/log/hbase",
+          "hbase_regionserver_xmn_ratio": "0.2"
+        }
+      }
+    },
+    {
+      "hbase-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n\n# Define some default values that can be overridden by system properties\nhbase.root.logger=INFO,console\nhbase.security.logger=INFO,console\nhbase.log.dir=.\nhbase.log.file=hbase.log\n\n# Define the root logger to the system property \"hbase.root.logger\".\nlog4j.rootLogger=${hbase.root.logger}\n\n# Logging Threshold\nlog4j.threshold=ALL\n\n#\n# Daily Rolling File Appender\n#\nlog4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFA.File=${hbase.log.dir}/${hbase.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern=.yyyy-MM-dd\n\n# 30-day backup\n#log4j.appender.DRFA.MaxBackupIndex=30\nlog4j.appender.DRFA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\nlog4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n# Rolling File Appender properties\nhbase.log.maxfilesize=256MB\nhbase.log.maxbackupindex=20\n\n# Rolling File Appender\nlog4j.appender.RFA=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFA.File=${hbase.log.dir}/${hbase.log.file}\n\nlog4j.appender.RFA.MaxFileSize=${hbase.log.maxfilesize}\nlog4j.appender.RFA.MaxBackupIndex=${hbase.log.maxbackupindex}\n\nlog4j.appender.RFA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n#\n# Security audit appender\n#\nhbase.security.log.file=SecurityAuth.audit\nhbase.security.log.maxfilesize=256MB\nhbase.security.log.maxbackupindex=20\nlog4j.appender.RFAS=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFAS.File=${hbase.log.dir}/${hbase.security.log.file}\nlog4j.appender.RFAS.MaxFileSize=${hbase.security.log.maxfilesize}\nlog4j.appender.RFAS.MaxBackupIndex=${hbase.security.log.maxbackupindex}\nlog4j.appender.RFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.category.SecurityLogger=${hbase.security.logger}\nlog4j.additivity.SecurityLogger=false\n#log4j.logger.SecurityLogger.org.apache.hadoop.hbase.security.access.AccessController=TRACE\n\n#\n# Null Appender\n#\nlog4j.appender.NullAppender=org.apache.log4j.varia.NullAppender\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n# Custom Logging levels\n\nlog4j.logger.org.apache.zookeeper=INFO\n#log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG\nlog4j.logger.org.apache.hadoop.hbase=DEBUG\n# Make these two classes INFO-level. Make them DEBUG to see more zk debug.\nlog4j.logger.org.apache.hadoop.hbase.zookeeper.ZKUtil=INFO\nlog4j.logger.org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher=INFO\n#log4j.logger.org.apache.hadoop.dfs=DEBUG\n# Set this class to log INFO only otherwise its OTT\n# Enable this to get detailed connection error/retry logging.\n# log4j.logger.org.apache.hadoop.hbase.client.HConnectionManager$HConnectionImplementation=TRACE\n\n\n# Uncomment this line to enable tracing on _every_ RPC call (this can be a lot of output)\n#log4j.logger.org.apache.hadoop.ipc.HBaseServer.trace=DEBUG\n\n# Uncomment the below if you want to remove logging of client region caching'\n# and scan of .META. messages\n# log4j.logger.org.apache.hadoop.hbase.client.HConnectionManager$HConnectionImplementation=INFO\n# log4j.logger.org.apache.hadoop.hbase.client.MetaScanner=INFO"
+        }
+      }
+    },
+    {
+      "hbase-policy": {
+        "properties": {
+          "security.client.protocol.acl": "*",
+          "security.admin.protocol.acl": "*",
+          "security.masterregion.protocol.acl": "*"
+        }
+      }
+    },
+    {
+      "hbase-site": {
+        "properties": {
+          "hbase.hregion.memstore.flush.size": "134217728",
+          "hbase.hstore.compactionThreshold": "3",
+          "hbase.local.dir": "${hbase.tmp.dir}/local",
+          "hbase.master.info.bindAddress": "0.0.0.0",
+          "hbase.security.authorization": "false",
+          "zookeeper.znode.parent": "/hbase-unsecure",
+          "hbase.security.authentication": "simple",
+          "hbase.master.port": "60000",
+          "hbase.regionserver.global.memstore.upperLimit": "0.4",
+          "hbase.hregion.majorcompaction": "604800000",
+          "hbase.client.keyvalue.maxsize": "10485760",
+          "hbase.client.scanner.caching": "100",
+          "hbase.master.info.port": "60010",
+          "hbase.coprocessor.region.classes": "",
+          "dfs.domain.socket.path": "/var/lib/hadoop-hdfs/dn_socket",
+          "hbase.cluster.distributed": "true",
+          "hbase.rootdir": "hdfs://%HOSTGROUP::host_group_master_1%:8020/apps/hbase/data",
+          "hbase.regionserver.info.port": "60030",
+          "hbase.regionserver.global.memstore.lowerLimit": "0.38",
+          "hbase.hregion.majorcompaction.jitter": "0.50",
+          "hbase.regionserver.handler.count": "60",
+          "hbase.coprocessor.master.classes": "",
+          "hbase.tmp.dir": "/mnt/hadoop/hbase",
+          "hbase.superuser": "hbase",
+          "hbase.hregion.memstore.mslab.enabled": "true",
+          "hbase.hstore.blockingStoreFiles": "10",
+          "hfile.block.cache.size": "0.40",
+          "hbase.zookeeper.useMulti": "true",
+          "hbase.hregion.max.filesize": "10737418240",
+          "hbase.defaults.for.version.skip": "true",
+          "hbase.hregion.memstore.block.multiplier": "4",
+          "zookeeper.session.timeout": "30000",
+          "hbase.zookeeper.property.clientPort": "2181",
+          "hbase.rpc.protection": "authentication",
+          "hbase.zookeeper.quorum": "%HOSTGROUP::host_group_master_1%,%HOSTGROUP::host_group_master_3%,%HOSTGROUP::host_group_master_2%"
+        }
+      }
+    },
+    {
+      "hcat-env": {
+        "properties": {
+          "content": "\n      # Licensed to the Apache Software Foundation (ASF) under one\n      # or more contributor license agreements. See the NOTICE file\n      # distributed with this work for additional information\n      # regarding copyright ownership. The ASF licenses this file\n      # to you under the Apache License, Version 2.0 (the\n      # \"License\"); you may not use this file except in compliance\n      # with the License. You may obtain a copy of the License at\n      #\n      # http://www.apache.org/licenses/LICENSE-2.0\n      #\n      # Unless required by applicable law or agreed to in writing, software\n      # distributed under the License is distributed on an \"AS IS\" BASIS,\n      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n      # See the License for the specific language governing permissions and\n      # limitations under the License.\n\n      JAVA_HOME={{java64_home}}\n      HCAT_PID_DIR={{hcat_pid_dir}}/\n      HCAT_LOG_DIR={{hcat_log_dir}}/\n      HCAT_CONF_DIR={{hcat_conf_dir}}\n      HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n      #DBROOT is the path where the connector jars are downloaded\n      DBROOT={{hcat_dbroot}}\n      USER={{hcat_user}}\n      METASTORE_PORT={{hive_metastore_port}}"
+        }
+      }
+    },
+    {
+      "hdfs-log4j": {
+        "properties": {
+          "content": "\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#  http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n\n\n# Define some default values that can be overridden by system properties\n# To change daemon root logger use hadoop_root_logger in hadoop-env\nhadoop.root.logger=INFO,console\nhadoop.log.dir=.\nhadoop.log.file=hadoop.log\n\n\n# Define the root logger to the system property \"hadoop.root.logger\".\nlog4j.rootLogger=${hadoop.root.logger}, EventCounter\n\n# Logging Threshold\nlog4j.threshhold=ALL\n\n#\n# Daily Rolling File Appender\n#\n\nlog4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFA.File=${hadoop.log.dir}/${hadoop.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern=.yyyy-MM-dd\n\n# 30-day backup\n#log4j.appender.DRFA.MaxBackupIndex=30\nlog4j.appender.DRFA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\nlog4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n# Debugging Pattern format\n#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\n\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\n\n#\n# TaskLog Appender\n#\n\n#Default values\nhadoop.tasklog.taskid=null\nhadoop.tasklog.iscleanup=false\nhadoop.tasklog.noKeepSplits=4\nhadoop.tasklog.totalLogFileSize=100\nhadoop.tasklog.purgeLogSplits=true\nhadoop.tasklog.logsRetainHours=12\n\nlog4j.appender.TLA=org.apache.hadoop.mapred.TaskLogAppender\nlog4j.appender.TLA.taskId=${hadoop.tasklog.taskid}\nlog4j.appender.TLA.isCleanup=${hadoop.tasklog.iscleanup}\nlog4j.appender.TLA.totalLogFileSize=${hadoop.tasklog.totalLogFileSize}\n\nlog4j.appender.TLA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.TLA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n\n#\n#Security audit appender\n#\nhadoop.security.logger=INFO,console\nhadoop.security.log.maxfilesize=256MB\nhadoop.security.log.maxbackupindex=20\nlog4j.category.SecurityLogger=${hadoop.security.logger}\nhadoop.security.log.file=SecurityAuth.audit\nlog4j.appender.DRFAS=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}\nlog4j.appender.DRFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.DRFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.appender.DRFAS.DatePattern=.yyyy-MM-dd\n\nlog4j.appender.RFAS=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}\nlog4j.appender.RFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.appender.RFAS.MaxFileSize=${hadoop.security.log.maxfilesize}\nlog4j.appender.RFAS.MaxBackupIndex=${hadoop.security.log.maxbackupindex}\n\n#\n# hdfs audit logging\n#\nhdfs.audit.logger=INFO,console\nlog4j.logger.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=${hdfs.audit.logger}\nlog4j.additivity.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=false\nlog4j.appender.DRFAAUDIT=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFAAUDIT.File=${hadoop.log.dir}/hdfs-audit.log\nlog4j.appender.DRFAAUDIT.layout=org.apache.log4j.PatternLayout\nlog4j.appender.DRFAAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n\nlog4j.appender.DRFAAUDIT.DatePattern=.yyyy-MM-dd\n\n#\n# mapred audit logging\n#\nmapred.audit.logger=INFO,console\nlog4j.logger.org.apache.hadoop.mapred.AuditLogger=${mapred.audit.logger}\nlog4j.additivity.org.apache.hadoop.mapred.AuditLogger=false\nlog4j.appender.MRAUDIT=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.MRAUDIT.File=${hadoop.log.dir}/mapred-audit.log\nlog4j.appender.MRAUDIT.layout=org.apache.log4j.PatternLayout\nlog4j.appender.MRAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n\nlog4j.appender.MRAUDIT.DatePattern=.yyyy-MM-dd\n\n#\n# Rolling File Appender\n#\n\nlog4j.appender.RFA=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFA.File=${hadoop.log.dir}/${hadoop.log.file}\n\n# Logfile size and and 30-day backups\nlog4j.appender.RFA.MaxFileSize=256MB\nlog4j.appender.RFA.MaxBackupIndex=10\n\nlog4j.appender.RFA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} - %m%n\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\n# Custom Logging levels\n\nhadoop.metrics.log.level=INFO\n#log4j.logger.org.apache.hadoop.mapred.JobTracker=DEBUG\n#log4j.logger.org.apache.hadoop.mapred.TaskTracker=DEBUG\n#log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG\nlog4j.logger.org.apache.hadoop.metrics2=${hadoop.metrics.log.level}\n\n# Jets3t library\nlog4j.logger.org.jets3t.service.impl.rest.httpclient.RestS3Service=ERROR\n\n#\n# Null Appender\n# Trap security logger on the hadoop client side\n#\nlog4j.appender.NullAppender=org.apache.log4j.varia.NullAppender\n\n#\n# Event Counter Appender\n# Sends counts of logging messages at different severity levels to Hadoop Metrics.\n#\nlog4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter\n\n# Removes \"deprecated\" messages\nlog4j.logger.org.apache.hadoop.conf.Configuration.deprecation=WARN\n\n#\n# HDFS block state change log from block manager\n#\n# Uncomment the following to suppress normal block state change\n# messages from BlockManager in NameNode.\n#log4j.logger.BlockStateChange=WARN"
+        }
+      }
+    },
+    {
+      "hdfs-site": {
+        "properties_attributes": {
+          "final": {
+            "dfs.support.append": "true",
+            "dfs.namenode.http-address": "true"
+          }
+        },
+        "properties": {
+          "dfs.datanode.data.dir": "/mnt/hadoop/hdfs/data",
+          "dfs.datanode.balance.bandwidthPerSec": "6250000",
+          "dfs.journalnode.http-address": "0.0.0.0:8480",
+          "dfs.namenode.https-address": "%HOSTGROUP::host_group_master_1%:50470",
+          "dfs.namenode.checkpoint.txns": "1000000",
+          "dfs.namenode.http-address": "%HOSTGROUP::host_group_master_1%:50070",
+          "dfs.permissions.superusergroup": "hdfs",
+          "dfs.datanode.http.address": "0.0.0.0:50075",
+          "dfs.namenode.avoid.write.stale.datanode": "true",
+          "dfs.datanode.address": "0.0.0.0:50010",
+          "dfs.datanode.https.address": "0.0.0.0:50475",
+          "dfs.datanode.failed.volumes.tolerated": "0",
+          "dfs.journalnode.edits.dir": "/hadoop/hdfs/journalnode",
+          "dfs.datanode.max.transfer.threads": "16384",
+          "dfs.namenode.startup.delay.block.deletion.sec": "3600",
+          "dfs.datanode.data.dir.perm": "750",
+          "dfs.datanode.du.reserved": "1073741824",
+          "dfs.support.append": "true",
+          "dfs.namenode.handler.count": "100",
+          "dfs.namenode.checkpoint.dir": "/mnt/hadoop/hdfs/namesecondary",
+          "dfs.http.policy": "HTTP_ONLY",
+          "dfs.domain.socket.path": "/var/lib/hadoop-hdfs/dn_socket",
+          "dfs.heartbeat.interval": "3",
+          "dfs.namenode.name.dir.restore": "true",
+          "dfs.cluster.administrators": " hdfs",
+          "dfs.namenode.name.dir": "/mnt/hadoop/hdfs/namenode",
+          "dfs.hosts.exclude": "/etc/hadoop/conf/dfs.exclude",
+          "dfs.namenode.write.stale.datanode.ratio": "1.0f",
+          "dfs.webhdfs.enabled": "true",
+          "dfs.blocksize": "134217728",
+          "fs.permissions.umask-mode": "022",
+          "dfs.namenode.checkpoint.period": "21600",
+          "dfs.namenode.safemode.threshold-pct": "1.0f",
+          "dfs.datanode.ipc.address": "0.0.0.0:8010",
+          "dfs.namenode.avoid.read.stale.datanode": "true",
+          "dfs.blockreport.initialDelay": "120",
+          "dfs.block.access.token.enable": "true",
+          "dfs.https.port": "50470",
+          "dfs.replication": "3",
+          "dfs.journalnode.https-address": "0.0.0.0:8481",
+          "dfs.namenode.stale.datanode.interval": "30000",
+          "dfs.client.read.shortcircuit": "true",
+          "dfs.client.read.shortcircuit.streams.cache.size": "4096",
+          "dfs.permissions.enabled": "true",
+          "dfs.namenode.secondary.http-address": "%HOSTGROUP::host_group_master_3%:50090",
+          "dfs.replication.max": "50",
+          "dfs.namenode.accesstime.precision": "0",
+          "dfs.namenode.checkpoint.edits.dir": "${dfs.namenode.checkpoint.dir}"
+        }
+      }
+    },
+    {
+      "hive-env": {
+        "properties": {
+          "webhcat_user": "hcat",
+          "hcat_pid_dir": "/var/run/webhcat",
+          "hive_log_dir": "/var/log/hive",
+          "hive_existing_oracle_host": "",
+          "hive_metastore_port": "9083",
+          "hive_user": "hive",
+          "hive_existing_mssql_server_2_host": "",
+          "hcat_log_dir": "/var/log/webhcat",
+          "hive_existing_mssql_server_host": "",
+          "hive_hostname": "%HOSTGROUP::host_group_master_2%",
+          "hcat_user": "hcat",
+          "content": "\n if [ \"$SERVICE\" = \"cli\" ]; then\n   if [ -z \"$DEBUG\" ]; then\n     export HADOOP_OPTS=\"$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:+UseParNewGC -XX:-UseGCOverheadLimit\"\n   else\n     export HADOOP_OPTS=\"$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:-UseGCOverheadLimit\"\n   fi\n fi\n\n# The heap size of the jvm stared by hive shell script can be controlled via:\n\n# Larger heap size may be required when running queries over large number of files or partitions.\n# By default hive shell scripts use a heap size of 256 (MB).  Larger heap size would also be\n# appropriate for hive server (hwi etc).\n\n\n# Set HADOOP_HOME to point to a specific hadoop install directory\nHADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\n# Hive Configuration Directory can be controlled by:\nexport HIVE_CONF_DIR={{hive_config_dir}}\n\n# Folder containing extra libraries required for hive compilation/execution can be controlled by:\nif [ \"${HIVE_AUX_JARS_PATH}\" != \"\" ]; then\n  if [ -f \"${HIVE_AUX_JARS_PATH}\" ]; then    \n    export HIVE_AUX_JARS_PATH=${HIVE_AUX_JARS_PATH}\n  elif [ -d \"/usr/hdp/current/hive-webhcat/share/hcatalog\" ]; then\n    export HIVE_AUX_JARS_PATH=/usr/hdp/current/hive-webhcat/share/hcatalog/hive-hcatalog-core.jar\n  fi\nelif [ -d \"/usr/hdp/current/hive-webhcat/share/hcatalog\" ]; then\n  export HIVE_AUX_JARS_PATH=/usr/hdp/current/hive-webhcat/share/hcatalog/hive-hcatalog-core.jar\nfi      \n\nexport METASTORE_PORT={{hive_metastore_port}}",
+          "hive_ambari_database": "MySQL",
+          "hive_ambari_host": "%HOSTGROUP::host_group_master_2%",
+          "hive_database": "New MySQL Database",
+          "hive_pid_dir": "/var/run/hive",
+          "hive_existing_postgresql_host": "",
+          "hive_database_type": "mysql",
+          "hive_existing_mysql_host": "",
+          "hive_database_name": "hive"
+        }
+      }
+    },
+    {
+      "hive-exec-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n# Define some default values that can be overridden by system properties\n\nhive.log.threshold=ALL\nhive.root.logger=INFO,FA\nhive.log.dir=${java.io.tmpdir}/${user.name}\nhive.query.id=hadoop\nhive.log.file=${hive.query.id}.log\n\n# Define the root logger to the system property \"hadoop.root.logger\".\nlog4j.rootLogger=${hive.root.logger}, EventCounter\n\n# Logging Threshold\nlog4j.threshhold=${hive.log.threshold}\n\n#\n# File Appender\n#\n\nlog4j.appender.FA=org.apache.log4j.FileAppender\nlog4j.appender.FA.File=${hive.log.dir}/${hive.log.file}\nlog4j.appender.FA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\n#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n# Debugging Pattern format\nlog4j.appender.FA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\n\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\n\n#custom logging levels\n#log4j.logger.xxx=DEBUG\n\n#\n# Event Counter Appender\n# Sends counts of logging messages at different severity levels to Hadoop Metrics.\n#\nlog4j.appender.EventCounter=org.apache.hadoop.hive.shims.HiveEventCounter\n\n\nlog4j.category.DataNucleus=ERROR,FA\nlog4j.category.Datastore=ERROR,FA\nlog4j.category.Datastore.Schema=ERROR,FA\nlog4j.category.JPOX.Datastore=ERROR,FA\nlog4j.category.JPOX.Plugin=ERROR,FA\nlog4j.category.JPOX.MetaData=ERROR,FA\nlog4j.category.JPOX.Query=ERROR,FA\nlog4j.category.JPOX.General=ERROR,FA\nlog4j.category.JPOX.Enhancer=ERROR,FA\n\n\n# Silence useless ZK logs\nlog4j.logger.org.apache.zookeeper.server.NIOServerCnxn=WARN,FA\nlog4j.logger.org.apache.zookeeper.ClientCnxnSocketNIO=WARN,FA"
+        }
+      }
+    },
+    {
+      "hive-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n# Define some default values that can be overridden by system properties\nhive.log.threshold=ALL\nhive.root.logger=INFO,DRFA\nhive.log.dir=${java.io.tmpdir}/${user.name}\nhive.log.file=hive.log\n\n# Define the root logger to the system property \"hadoop.root.logger\".\nlog4j.rootLogger=${hive.root.logger}, EventCounter\n\n# Logging Threshold\nlog4j.threshold=${hive.log.threshold}\n\n#\n# Daily Rolling File Appender\n#\n# Use the PidDailyerRollingFileAppend class instead if you want to use separate log files\n# for different CLI session.\n#\n# log4j.appender.DRFA=org.apache.hadoop.hive.ql.log.PidDailyRollingFileAppender\n\nlog4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender\n\nlog4j.appender.DRFA.File=${hive.log.dir}/${hive.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern=.yyyy-MM-dd\n\n# 30-day backup\n#log4j.appender.DRFA.MaxBackupIndex=30\nlog4j.appender.DRFA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\n#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n# Debugging Pattern format\nlog4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t]: %c{2} (%F:%M(%L)) - %m%n\n\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\n\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} [%t]: %p %c{2}: %m%n\nlog4j.appender.console.encoding=UTF-8\n\n#custom logging levels\n#log4j.logger.xxx=DEBUG\n\n#\n# Event Counter Appender\n# Sends counts of logging messages at different severity levels to Hadoop Metrics.\n#\nlog4j.appender.EventCounter=org.apache.hadoop.hive.shims.HiveEventCounter\n\n\nlog4j.category.DataNucleus=ERROR,DRFA\nlog4j.category.Datastore=ERROR,DRFA\nlog4j.category.Datastore.Schema=ERROR,DRFA\nlog4j.category.JPOX.Datastore=ERROR,DRFA\nlog4j.category.JPOX.Plugin=ERROR,DRFA\nlog4j.category.JPOX.MetaData=ERROR,DRFA\nlog4j.category.JPOX.Query=ERROR,DRFA\nlog4j.category.JPOX.General=ERROR,DRFA\nlog4j.category.JPOX.Enhancer=ERROR,DRFA\n\n\n# Silence useless ZK logs\nlog4j.logger.org.apache.zookeeper.server.NIOServerCnxn=WARN,DRFA\nlog4j.logger.org.apache.zookeeper.ClientCnxnSocketNIO=WARN,DRFA"
+        }
+      }
+    },
+    {
+      "hive-site": {
+        "properties": {
+          "hive.security.authenticator.manager": "org.apache.hadoop.hive.ql.security.ProxyUserAuthenticator",
+          "datanucleus.cache.level2.type": "none",
+          "hive.stats.autogather": "true",
+          "hive.enforce.sorting": "true",
+          "hive.optimize.index.filter": "true",
+          "hive.metastore.uris": "thrift://%HOSTGROUP::host_group_master_2%:9083",
+          "hive.stats.dbclass": "fs",
+          "hive.map.aggr.hash.force.flush.memory.threshold": "0.9",
+          "hive.server2.transport.mode": "binary",
+          "hive.compactor.worker.timeout": "86400L",
+          "hive.convert.join.bucket.mapjoin.tez": "false",
+          "hive.metastore.pre.event.listeners": "org.apache.hadoop.hive.ql.security.authorization.AuthorizationPreEventListener",
+          "hive.tez.container.size": "682",
+          "javax.jdo.option.ConnectionURL": "jdbc:mysql://%HOSTGROUP::host_group_master_2%/hive?createDatabaseIfNotExist=true",
+          "hive.server2.enable.doAs": "true",
+          "hive.metastore.client.socket.timeout": "1800s",
+          "hive.metastore.warehouse.dir": "/apps/hive/warehouse",
+          "hive.exec.orc.default.compress": "ZLIB",
+          "hive.exec.post.hooks": "org.apache.hadoop.hive.ql.hooks.ATSHook",
+          "hive.exec.dynamic.partition": "true",
+          "hive.enforce.sortmergebucketmapjoin": "true",
+          "javax.jdo.option.ConnectionDriverName": "com.mysql.jdbc.Driver",
+          "hive.metastore.kerberos.principal": "hive/_HOST@EXAMPLE.COM",
+          "hive.server2.thrift.http.port": "10001",
+          "hive.exec.pre.hooks": "org.apache.hadoop.hive.ql.hooks.ATSHook",
+          "hive.metastore.client.connect.retry.delay": "5s",
+          "hive.exec.failure.hooks": "org.apache.hadoop.hive.ql.hooks.ATSHook",
+          "hive.prewarm.enabled": "false",
+          "hive.server2.tez.default.queues": "default",
+          "hive.exec.dynamic.partition.mode": "nonstrict",
+          "hive.compute.query.using.stats": "true",
+          "hive.optimize.metadataonly": "true",
+          "hive.server2.thrift.max.worker.threads": "500",
+          "hive.compactor.check.interval": "300L",
+          "hive.metastore.kerberos.keytab.file": "/etc/security/keytabs/hive.service.keytab",
+          "hive.prewarm.numcontainers": "10",
+          "hive.cluster.delegation.token.store.zookeeper.connectString": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181",
+          "hive.security.metastore.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.StorageBasedAuthorizationProvider,org.apache.hadoop.hive.ql.security.authorization.MetaStoreAuthzAPIAuthorizerEmbedOnly",
+          "hive.mapjoin.bucket.cache.size": "10000",
+          "hive.exec.orc.default.stripe.size": "67108864",
+          "hive.merge.rcfile.block.level": "true",
+          "hive.server2.table.type.mapping": "CLASSIC",
+          "hive.exec.parallel.thread.number": "8",
+          "hive.tez.dynamic.partition.pruning": "true",
+          "hive.security.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdConfOnlyAuthorizerFactory",
+          "hive.server2.logging.operation.log.location": "${system:java.io.tmpdir}/${system:user.name}/operation_logs",
+          "hive.metastore.failure.retries": "24",
+          "hive.server2.logging.operation.enabled": "true",
+          "hive.cluster.delegation.token.store.class": "org.apache.hadoop.hive.thrift.ZooKeeperTokenStore",
+          "hive.tez.max.partition.factor": "2.0",
+          "hive.optimize.null.scan": "true",
+          "hive.cluster.delegation.token.store.zookeeper.znode": "/hive/cluster/delegation",
+          "hive.metastore.sasl.enabled": "false",
+          "hive.server2.authentication": "NONE",
+          "hive.tez.java.opts": "-server -Xmx546m -Djava.net.preferIPv4Stack=true -XX:NewRatio=8 -XX:+UseNUMA -XX:+UseParallelGC -XX:+PrintGCDetails -verbose:gc -XX:+PrintGCTimeStamps",
+          "hive.mapjoin.optimized.hashtable": "true",
+          "hive.optimize.bucketmapjoin.sortedmerge": "false",
+          "hive.optimize.reducededuplication.min.reducer": "4",
+          "hive.compactor.abortedtxn.threshold": "1000",
+          "hive.server2.zookeeper.namespace": "hiveserver2",
+          "hive.exec.max.dynamic.partitions.pernode": "2000",
+          "ambari.hive.db.schema.name": "hive",
+          "hive.merge.smallfiles.avgsize": "16000000",
+          "hive.conf.restricted.list": "hive.security.authenticator.manager,hive.security.authorization.manager,hive.users.in.admin.role",
+          "hive.map.aggr.hash.percentmemory": "0.5",
+          "hive.tez.dynamic.partition.pruning.max.event.size": "1048576",
+          "hive.security.metastore.authenticator.manager": "org.apache.hadoop.hive.ql.security.HadoopDefaultMetastoreAuthenticator",
+          "hive.fetch.task.conversion": "more",
+          "hive.execution.engine": "tez",
+          "hive.fetch.task.conversion.threshold": "1073741824",
+          "hive.limit.optimize.enable": "true",
+          "hive.merge.size.per.task": "256000000",
+          "hive.server2.use.SSL": "false",
+          "hive.server2.thrift.sasl.qop": "auth",
+          "hive.exec.max.dynamic.partitions": "5000",
+          "javax.jdo.option.ConnectionUserName": "hive",
+          "hive.auto.convert.join.noconditionaltask": "true",
+          "hive.server2.tez.sessions.per.default.queue": "1",
+          "hive.server2.tez.initialize.default.sessions": "false",
+          "hive.metastore.authorization.storage.checks": "false",
+          "hive.exec.reducers.max": "1009",
+          "hive.map.aggr.hash.min.reduction": "0.5",
+          "hive.fetch.task.aggr": "false",
+          "hive.tez.min.partition.factor": "0.25",
+          "hive.mapred.reduce.tasks.speculative.execution": "false",
+          "hive.vectorized.groupby.flush.percent": "0.1",
+          "hive.server2.thrift.http.path": "cliservice",
+          "hive.tez.smb.number.waves": "0.5",
+          "hive.limit.pushdown.memory.usage": "0.04",
+          "hive.server2.authentication.spnego.principal": "/etc/security/keytabs/spnego.service.keytab",
+          "hive.vectorized.groupby.maxentries": "100000",
+          "hive.optimize.reducededuplication": "true",
+          "hive.exec.submit.local.task.via.child": "true",
+          "hive.exec.parallel": "false",
+          "hive.tez.auto.reducer.parallelism": "false",
+          "hive.auto.convert.join.noconditionaltask.size": "238026752",
+          "hive.support.concurrency": "false",
+          "hive.tez.dynamic.partition.pruning.max.data.size": "104857600",
+          "hive.server2.support.dynamic.service.discovery": "true",
+          "hive.exec.reducers.bytes.per.reducer": "67108864",
+          "hive.exec.compress.output": "false",
+          "hive.stats.fetch.column.stats": "false",
+          "hive.user.install.directory": "/user/",
+          "hive.exec.max.created.files": "100000",
+          "hive.tez.log.level": "INFO",
+          "hive.cbo.enable": "true",
+          "hive.tez.cpu.vcores": "-1",
+          "hive.auto.convert.join": "true",
+          "hive.merge.tezfiles": "false",
+          "hive.compactor.delta.pct.threshold": "0.1f",
+          "hive.stats.fetch.partition.stats": "true",
+          "hive.exec.scratchdir": "/tmp/hive",
+          "hive.merge.mapfiles": "true",
+          "hive.optimize.constant.propagation": "true",
+          "hive.merge.orcfile.stripe.level": "true",
+          "hive.txn.manager": "org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager",
+          "hive.vectorized.groupby.checkinterval": "4096",
+          "hive.vectorized.execution.reduce.enabled": "false",
+          "hive.zookeeper.quorum": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181",
+          "hive.cli.print.header": "false",
+          "hive.auto.convert.sortmerge.join": "true",
+          "hive.compactor.delta.num.threshold": "10",
+          "hive.zookeeper.namespace": "hive_zookeeper_namespace",
+          "hive.orc.compute.splits.num.threads": "10",
+          "hive.orc.splits.include.file.footer": "false",
+          "hive.security.metastore.authorization.auth.reads": "true",
+          "hive.txn.max.open.batch": "1000",
+          "hive.auto.convert.sortmerge.join.to.mapjoin": "false",
+          "hive.map.aggr": "true",
+          "hive.server2.allow.user.substitution": "true",
+          "hive.compactor.initiator.on": "false",
+          "hive.enforce.bucketing": "true",
+          "hive.optimize.sort.dynamic.partition": "false",
+          "hive.vectorized.execution.enabled": "true",
+          "hive.txn.timeout": "300",
+          "hive.metastore.cache.pinobjtypes": "Table,Database,Type,FieldSchema,Order",
+          "hive.server2.authentication.spnego.keytab": "HTTP/_HOST@EXAMPLE.COM",
+          "hive.metastore.execute.setugi": "true",
+          "hive.server2.thrift.port": "10000",
+          "hive.tez.input.format": "org.apache.hadoop.hive.ql.io.HiveInputFormat",
+          "hive.merge.mapredfiles": "false",
+          "hive.optimize.bucketmapjoin": "true",
+          "hive.exec.compress.intermediate": "false",
+          "hive.security.authorization.enabled": "false",
+          "hive.smbjoin.cache.rows": "10000",
+          "hive.exec.orc.compression.strategy": "SPEED",
+          "hive.metastore.connect.retries": "24",
+          "hive.metastore.server.max.threads": "100000",
+          "hive.zookeeper.client.port": "2181",
+          "hive.exec.submitviachild": "false",
+          "hive.compactor.worker.threads": "0"
+        }
+      }
+    },
+    {
+      "hiveserver2-site": {
+        "properties": {
+          "hive.security.authenticator.manager": "org.apache.hadoop.hive.ql.security.SessionStateUserAuthenticator",
+          "hive.security.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory"
+        }
+      }
+    },
+    {
+      "kafka-broker": {
+        "properties": {
+          "log.roll.hours": "168",
+          "controlled.shutdown.max.retries": "3",
+          "zookeeper.connection.timeout.ms": "6000",
+          "kafka.timeline.metrics.reporter.enabled": "true",
+          "controller.socket.timeout.ms": "30000",
+          "zookeeper.session.timeout.ms": "30000",
+          "kafka.timeline.metrics.port": "{{metric_collector_port}}",
+          "controlled.shutdown.enable": "false",
+          "message.max.bytes": "1000000",
+          "kafka.ganglia.metrics.group": "kafka",
+          "replica.lag.time.max.ms": "10000",
+          "controller.message.queue.size": "10",
+          "auto.create.topics.enable": "true",
+          "kafka.ganglia.metrics.port": "8671",
+          "zookeeper.sync.time.ms": "2000",
+          "replica.fetch.max.bytes": "1048576",
+          "log.retention.hours": "168",
+          "log.dirs": "/mnt/kafka-logs",
+          "log.index.size.max.bytes": "10485760",
+          "log.cleanup.interval.mins": "10",
+          "fetch.purgatory.purge.interval.requests": "10000",
+          "log.retention.bytes": "-1",
+          "replica.fetch.wait.max.ms": "500",
+          "port": "6667",
+          "kafka.timeline.metrics.reporter.sendInterval": "5900",
+          "log.segment.bytes": "1073741824",
+          "controlled.shutdown.retry.backoff.ms": "5000",
+          "producer.purgatory.purge.interval.requests": "10000",
+          "log.flush.scheduler.interval.ms": "3000",
+          "socket.receive.buffer.bytes": "102400",
+          "num.partitions": "1",
+          "num.io.threads": "8",
+          "kafka.timeline.metrics.maxRowCacheSize": "10000",
+          "num.network.threads": "3",
+          "socket.request.max.bytes": "104857600",
+          "replica.lag.max.messages": "4000",
+          "queued.max.requests": "500",
+          "zookeeper.connect": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181",
+          "replica.socket.timeout.ms": "30000",
+          "replica.high.watermark.checkpoint.interval.ms": "5000",
+          "log.flush.interval.messages": "10000",
+          "socket.send.buffer.bytes": "102400",
+          "log.flush.interval.ms": "3000",
+          "kafka.metrics.reporters": "{{kafka_metrics_reporters}}",
+          "num.replica.fetchers": "1",
+          "default.replication.factor": "1",
+          "replica.socket.receive.buffer.bytes": "65536",
+          "log.index.interval.bytes": "4096",
+          "kafka.ganglia.metrics.reporter.enabled": "true",
+          "kafka.timeline.metrics.host": "{{metric_collector_host}}",
+          "replica.fetch.min.bytes": "1"
+        }
+      }
+    },
+    {
+      "kafka-env": {
+        "properties": {
+          "content": "\n#!/bin/bash\n\n# Set KAFKA specific environment variables here.\n\n# The java implementation to use.\nexport JAVA_HOME={{java64_home}}\nexport PATH=$PATH:$JAVA_HOME/bin\nexport PID_DIR={{kafka_pid_dir}}\nexport LOG_DIR={{kafka_log_dir}}\n\n# Add kafka sink to classpath and related depenencies\nif [ -e \"/usr/lib/ambari-metrics-kafka-sink/ambari-metrics-kafka-sink.jar\" ]; then\n  export CLASSPATH=$CLASSPATH:/usr/lib/ambari-metrics-kafka-sink/ambari-metrics-kafka-sink.jar\n  export CLASSPATH=$CLASSPATH:/usr/lib/ambari-metrics-kafka-sink/lib/*\nfi",
+          "kafka_pid_dir": "/var/run/kafka",
+          "kafka_log_dir": "/var/log/kafka",
+          "kafka_user": "kafka"
+        }
+      }
+    },
+    {
+      "kafka-log4j": {
+        "properties": {
+          "content": "\n#\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n#\n#\nkafka.logs.dir=logs\n\nlog4j.rootLogger=INFO, stdout\n\nlog4j.appender.stdout=org.apache.log4j.ConsoleAppender\nlog4j.appender.stdout.layout=org.apache.log4j.PatternLayout\nlog4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log\nlog4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.stateChangeAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log\nlog4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log\nlog4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.cleanerAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log\nlog4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log\nlog4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\n# Turn on all our debugging info\n#log4j.logger.kafka.producer.async.DefaultEventHandler=DEBUG, kafkaAppender\n#log4j.logger.kafka.client.ClientUtils=DEBUG, kafkaAppender\n#log4j.logger.kafka.perf=DEBUG, kafkaAppender\n#log4j.logger.kafka.perf.ProducerPerformance$ProducerThread=DEBUG, kafkaAppender\n#log4j.logger.org.I0Itec.zkclient.ZkClient=DEBUG\nlog4j.logger.kafka=INFO, kafkaAppender\nlog4j.logger.kafka.network.RequestChannel$=WARN, requestAppender\nlog4j.additivity.kafka.network.RequestChannel$=false\n\n#log4j.logger.kafka.network.Processor=TRACE, requestAppender\n#log4j.logger.kafka.server.KafkaApis=TRACE, requestAppender\n#log4j.additivity.kafka.server.KafkaApis=false\nlog4j.logger.kafka.request.logger=WARN, requestAppender\nlog4j.additivity.kafka.request.logger=false\n\nlog4j.logger.kafka.controller=TRACE, controllerAppender\nlog4j.additivity.kafka.controller=false\n\nlog4j.logger.kafka.log.LogCleaner=INFO, cleanerAppender\nlog4j.additivity.kafka.log.LogCleaner=false\n\nlog4j.logger.state.change.logger=TRACE, stateChangeAppender\nlog4j.additivity.state.change.logger=false"
+        }
+      }
+    },
+    {
+      "knox-env": {
+        "properties": {
+          "knox_group": "knox",
+          "knox_pid_dir": "/var/run/knox",
+          "knox_user": "knox"
+        }
+      }
+    },
+    {
+      "ldap-log4j": {
+        "properties": {
+          "content": "\n        # Licensed to the Apache Software Foundation (ASF) under one\n        # or more contributor license agreements.  See the NOTICE file\n        # distributed with this work for additional information\n        # regarding copyright ownership.  The ASF licenses this file\n        # to you under the Apache License, Version 2.0 (the\n        # \"License\"); you may not use this file except in compliance\n        # with the License.  You may obtain a copy of the License at\n        #\n        #     http://www.apache.org/licenses/LICENSE-2.0\n        #\n        # Unless required by applicable law or agreed to in writing, software\n        # distributed under the License is distributed on an \"AS IS\" BASIS,\n        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n        # See the License for the specific language governing permissions and\n        # limitations under the License.\n\n        app.log.dir=${launcher.dir}/../logs\n        app.log.file=${launcher.name}.log\n\n        log4j.rootLogger=ERROR, drfa\n        log4j.logger.org.apache.directory.server.ldap.LdapServer=INFO\n        log4j.logger.org.apache.directory=WARN\n\n        log4j.appender.stdout=org.apache.log4j.ConsoleAppender\n        log4j.appender.stdout.layout=org.apache.log4j.PatternLayout\n        log4j.appender.stdout.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\n\n        log4j.appender.drfa=org.apache.log4j.DailyRollingFileAppender\n        log4j.appender.drfa.File=${app.log.dir}/${app.log.file}\n        log4j.appender.drfa.DatePattern=.yyyy-MM-dd\n        log4j.appender.drfa.layout=org.apache.log4j.PatternLayout\n        log4j.appender.drfa.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n"
+        }
+      }
+    },
+    {
+      "mapred-env": {
+        "properties": {
+          "content": "\n# export JAVA_HOME=/home/y/libexec/jdk1.6.0/\n\nexport HADOOP_JOB_HISTORYSERVER_HEAPSIZE={{jobhistory_heapsize}}\n\nexport HADOOP_MAPRED_ROOT_LOGGER=INFO,RFA\n\n#export HADOOP_JOB_HISTORYSERVER_OPTS=\n#export HADOOP_MAPRED_LOG_DIR=\"\" # Where log files are stored.  $HADOOP_MAPRED_HOME/logs by default.\n#export HADOOP_JHS_LOGGER=INFO,RFA # Hadoop JobSummary logger.\n#export HADOOP_MAPRED_PID_DIR= # The pid files are stored. /tmp by default.\n#export HADOOP_MAPRED_IDENT_STRING= #A string representing this instance of hadoop. $USER by default\n#export HADOOP_MAPRED_NICENESS= #The scheduling priority for daemons. Defaults to 0.\nexport HADOOP_OPTS=\"-Dhdp.version=$HDP_VERSION $HADOOP_OPTS\"",
+          "mapred_log_dir_prefix": "/var/log/hadoop-mapreduce",
+          "mapred_pid_dir_prefix": "/var/run/hadoop-mapreduce",
+          "jobhistory_heapsize": "900",
+          "mapred_user": "mapred"
+        }
+      }
+    },
+    {
+      "mapred-site": {
+        "properties": {
+          "mapreduce.map.log.level": "INFO",
+          "mapreduce.jobhistory.bind-host": "0.0.0.0",
+          "mapreduce.application.classpath": "$PWD/mr-framework/hadoop/share/hadoop/mapreduce/*:$PWD/mr-framework/hadoop/share/hadoop/mapreduce/lib/*:$PWD/mr-framework/hadoop/share/hadoop/common/*:$PWD/mr-framework/hadoop/share/hadoop/common/lib/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/lib/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/lib/*:/usr/hdp/${hdp.version}/hadoop/lib/hadoop-lzo-0.6.0.${hdp.version}.jar:/etc/hadoop/conf/secure",
+          "mapreduce.shuffle.port": "13562",
+          "mapreduce.output.fileoutputformat.compress.type": "BLOCK",
+          "mapreduce.reduce.shuffle.merge.percent": "0.66",
+          "mapreduce.reduce.shuffle.input.buffer.percent": "0.7",
+          "mapreduce.map.speculative": "false",
+          "mapreduce.output.fileoutputformat.compress": "false",
+          "mapreduce.task.timeout": "300000",
+          "mapreduce.job.emit-timeline-data": "false",
+          "yarn.app.mapreduce.am.log.level": "INFO",
+          "mapreduce.task.io.sort.mb": "273",
+          "mapreduce.reduce.log.level": "INFO",
+          "mapreduce.reduce.memory.mb": "682",
+          "mapreduce.task.io.sort.factor": "100",
+          "mapreduce.admin.reduce.child.java.opts": "-server -XX:NewRatio=8 -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}",
+          "mapreduce.jobhistory.intermediate-done-dir": "/mr-history/tmp",
+          "mapreduce.reduce.shuffle.fetch.retry.enabled": "1",
+          "mapreduce.map.output.compress": "false",
+          "mapreduce.jobhistory.address": "%HOSTGROUP::host_group_master_1%:10020",
+          "yarn.app.mapreduce.am.staging-dir": "/user",
+          "mapreduce.am.max-attempts": "2",
+          "yarn.app.mapreduce.am.admin-command-opts": "-Dhdp.version=${hdp.version}",
+          "mapreduce.cluster.administrators": " hadoop",
+          "mapreduce.map.sort.spill.percent": "0.7",
+          "mapreduce.jobhistory.done-dir": "/mr-history/done",
+          "mapreduce.framework.name": "yarn",
+          "mapreduce.reduce.shuffle.fetch.retry.timeout-ms": "30000",
+          "mapreduce.reduce.shuffle.fetch.retry.interval-ms": "1000",
+          "mapreduce.reduce.java.opts": "-Xmx546m",
+          "mapreduce.reduce.shuffle.parallelcopies": "30",
+          "mapreduce.map.java.opts": "-Xmx546m",
+          "mapreduce.reduce.input.buffer.percent": "0.0",
+          "mapreduce.application.framework.path": "/hdp/apps/${hdp.version}/mapreduce/mapreduce.tar.gz#mr-framework",
+          "mapreduce.jobhistory.webapp.address": "%HOSTGROUP::host_group_master_1%:19888",
+          "yarn.app.mapreduce.am.command-opts": "-Xmx546m -Dhdp.version=${hdp.version}",
+          "mapreduce.map.memory.mb": "682",
+          "yarn.app.mapreduce.am.resource.mb": "682",
+          "mapreduce.admin.user.env": "LD_LIBRARY_PATH=/usr/hdp/${hdp.version}/hadoop/lib/native:/usr/hdp/${hdp.version}/hadoop/lib/native/Linux-amd64-64",
+          "mapreduce.job.reduce.slowstart.completedmaps": "0.05",
+          "mapreduce.reduce.speculative": "false",
+          "mapreduce.admin.map.child.java.opts": "-server -XX:NewRatio=8 -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}"
+        }
+      }
+    },
+    {
+      "oozie-env": {
+        "properties": {
+          "oozie_derby_database": "Derby",
+          "content": "\n#!/bin/bash\n\nif [ -d \"/usr/lib/bigtop-tomcat\" ]; then\n  export OOZIE_CONFIG=${OOZIE_CONFIG:-/etc/oozie/conf}\n  export CATALINA_BASE=${CATALINA_BASE:-{{oozie_server_dir}}}\n  export CATALINA_TMPDIR=${CATALINA_TMPDIR:-/var/tmp/oozie}\n  export OOZIE_CATALINA_HOME=/usr/lib/bigtop-tomcat\nfi\n\n#Set JAVA HOME\nexport JAVA_HOME={{java_home}}\n\nexport JRE_HOME=${JAVA_HOME}\n\n# Set Oozie specific environment variables here.\n\n# Settings for the Embedded Tomcat that runs Oozie\n# Java System properties for Oozie should be specified in this variable\n#\n# export CATALINA_OPTS=\n\n# Oozie configuration file to load from Oozie configuration directory\n#\n# export OOZIE_CONFIG_FILE=oozie-site.xml\n\n# Oozie logs directory\n#\nexport OOZIE_LOG={{oozie_log_dir}}\n\n# Oozie pid directory\n#\nexport CATALINA_PID={{pid_file}}\n\n#Location of the data for oozie\nexport OOZIE_DATA={{oozie_data_dir}}\n\n# Oozie Log4J configuration file to load from Oozie configuration directory\n#\n# export OOZIE_LOG4J_FILE=oozie-log4j.properties\n\n# Reload interval of the Log4J configuration file, in seconds\n#\n# export OOZIE_LOG4J_RELOAD=10\n\n# The port Oozie server runs\n#\nexport OOZIE_HTTP_PORT={{oozie_server_port}}\n\n# The admin port Oozie server runs\n#\nexport OOZIE_ADMIN_PORT={{oozie_server_admin_port}}\n\n# The host name Oozie server runs on\n#\n# export OOZIE_HTTP_HOSTNAME=`hostname -f`\n\n# The base URL for callback URLs to Oozie\n#\n# export OOZIE_BASE_URL=\"http://${OOZIE_HTTP_HOSTNAME}:${OOZIE_HTTP_PORT}/oozie\"\nexport JAVA_LIBRARY_PATH={{hadoop_lib_home}}/native/Linux-amd64-64\n\n# At least 1 minute of retry time to account for server downtime during\n# upgrade/downgrade\nexport OOZIE_CLIENT_OPTS=\"${OOZIE_CLIENT_OPTS} -Doozie.connection.retry.count=5 \"\n\n# This is needed so that Oozie does not run into OOM or GC Overhead limit\n# exceeded exceptions. If the oozie server is handling large number of\n# workflows/coordinator jobs, the memory settings may need to be revised\nexport CATALINA_OPTS=\"${CATALINA_OPTS} -Xmx2048m -XX:MaxPermSize=256m \"",
+          "oozie_heapsize": "2048m",
+          "oozie_data_dir": "/mnt/hadoop/oozie/data",
+          "oozie_admin_port": "11001",
+          "oozie_existing_postgresql_host": "",
+          "oozie_log_dir": "/var/log/oozie",
+          "oozie_permsize": "256m",
+          "oozie_hostname": "%HOSTGROUP::host_group_master_1%",
+          "oozie_database": "New Derby Database",
+          "oozie_pid_dir": "/var/run/oozie",
+          "oozie_existing_oracle_host": "",
+          "oozie_user": "oozie"
+        }
+      }
+    },
+    {
+      "oozie-log4j": {
+        "properties": {
+          "content": "\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#    http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License. See accompanying LICENSE file.\n#\n\n# If the Java System property 'oozie.log.dir' is not defined at Oozie start up time\n# XLogService sets its value to '${oozie.home}/logs'\n\nlog4j.appender.oozie=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.oozie.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.oozie.File=${oozie.log.dir}/oozie.log\nlog4j.appender.oozie.Append=true\nlog4j.appender.oozie.layout=org.apache.log4j.PatternLayout\nlog4j.appender.oozie.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - SERVER[${oozie.instance.id}] %m%n\n\nlog4j.appender.oozieops=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.oozieops.DatePattern='.'yyyy-MM-dd\nlog4j.appender.oozieops.File=${oozie.log.dir}/oozie-ops.log\nlog4j.appender.oozieops.Append=true\nlog4j.appender.oozieops.layout=org.apache.log4j.PatternLayout\nlog4j.appender.oozieops.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - %m%n\n\nlog4j.appender.oozieinstrumentation=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.oozieinstrumentation.DatePattern='.'yyyy-MM-dd\nlog4j.appender.oozieinstrumentation.File=${oozie.log.dir}/oozie-instrumentation.log\nlog4j.appender.oozieinstrumentation.Append=true\nlog4j.appender.oozieinstrumentation.layout=org.apache.log4j.PatternLayout\nlog4j.appender.oozieinstrumentation.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - %m%n\n\nlog4j.appender.oozieaudit=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.oozieaudit.DatePattern='.'yyyy-MM-dd\nlog4j.appender.oozieaudit.File=${oozie.log.dir}/oozie-audit.log\nlog4j.appender.oozieaudit.Append=true\nlog4j.appender.oozieaudit.layout=org.apache.log4j.PatternLayout\nlog4j.appender.oozieaudit.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - %m%n\n\nlog4j.appender.openjpa=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.openjpa.DatePattern='.'yyyy-MM-dd\nlog4j.appender.openjpa.File=${oozie.log.dir}/oozie-jpa.log\nlog4j.appender.openjpa.Append=true\nlog4j.appender.openjpa.layout=org.apache.log4j.PatternLayout\nlog4j.appender.openjpa.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - %m%n\n\nlog4j.logger.openjpa=INFO, openjpa\nlog4j.logger.oozieops=INFO, oozieops\nlog4j.logger.oozieinstrumentation=ALL, oozieinstrumentation\nlog4j.logger.oozieaudit=ALL, oozieaudit\nlog4j.logger.org.apache.oozie=INFO, oozie\nlog4j.logger.org.apache.hadoop=WARN, oozie\nlog4j.logger.org.mortbay=WARN, oozie\nlog4j.logger.org.hsqldb=WARN, oozie\nlog4j.logger.org.apache.hadoop.security.authentication.server=INFO, oozie"
+        }
+      }
+    },
+    {
+      "oozie-site": {
+        "properties": {
+          "oozie.service.AuthorizationService.security.enabled": "true",
+          "oozie.service.PurgeService.purge.interval": "3600",
+          "oozie.service.PurgeService.older.than": "30",
+          "oozie.service.ProxyUserService.proxyuser.falcon.groups": "*",
+          "oozie.system.id": "oozie-${user.name}",
+          "oozie.service.ELService.ext.functions.coord-sla-submit": "\n      instanceTime=org.apache.oozie.coord.CoordELFunctions#ph1_coord_nominalTime_echo_fixed,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.HadoopAccessorService.kerberos.enabled": "false",
+          "oozie.service.coord.normal.default.timeout": "120",
+          "oozie.service.JPAService.pool.max.active.conn": "10",
+          "oozie.authentication.type": "simple",
+          "use.system.libpath.for.mapreduce.and.pig.jobs": "false",
+          "oozie.service.CallableQueueService.callable.concurrency": "3",
+          "oozie.service.CallableQueueService.threads": "10",
+          "oozie.service.coord.push.check.requeue.interval": "30000",
+          "oozie.service.ProxyUserService.proxyuser.falcon.hosts": "*",
+          "oozie.credentials.credentialclasses": "hcat=org.apache.oozie.action.hadoop.HCatCredentials",
+          "oozie.service.coord.check.maximum.frequency": "false",
+          "oozie.base.url": "http://%HOSTGROUP::host_group_master_1%:11000/oozie",
+          "oozie.service.CallableQueueService.queue.size": "1000",
+          "oozie.service.ELService.ext.functions.coord-sla-create": "\n      instanceTime=org.apache.oozie.coord.CoordELFunctions#ph2_coord_nominalTime,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.JPAService.jdbc.username": "oozie",
+          "oozie.authentication.kerberos.name.rules": "\n      RULE:[2:$1@$0]([jt]t@.*TODO-KERBEROS-DOMAIN)s/.*/TODO-MAPREDUSER/\n      RULE:[2:$1@$0]([nd]n@.*TODO-KERBEROS-DOMAIN)s/.*/TODO-HDFSUSER/\n      RULE:[2:$1@$0](hm@.*TODO-KERBEROS-DOMAIN)s/.*/TODO-HBASE-USER/\n      RULE:[2:$1@$0](rs@.*TODO-KERBEROS-DOMAIN)s/.*/TODO-HBASE-USER/\n      DEFAULT",
+          "oozie.service.SchemaService.wf.ext.schemas": "shell-action-0.1.xsd,shell-action-0.2.xsd,shell-action-0.3.xsd,email-action-0.1.xsd,email-action-0.2.xsd,hive-action-0.2.xsd,hive-action-0.3.xsd,hive-action-0.4.xsd,hive-action-0.5.xsd,sqoop-action-0.2.xsd,sqoop-action-0.3.xsd,sqoop-action-0.4.xsd,ssh-action-0.1.xsd,ssh-action-0.2.xsd,distcp-action-0.1.xsd,distcp-action-0.2.xsd,oozie-sla-0.1.xsd,oozie-sla-0.2.xsd",
+          "oozie.service.ELService.ext.functions.coord-action-create": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph2_now,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph2_today,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph2_yesterday,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_currentMonth,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_lastMonth,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph2_currentYear,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph2_lastYear,\n      latest=org.apache.oozie.coord.CoordELFunctions#ph2_coord_latest_echo,\n      future=org.apache.oozie.coord.CoordELFunctions#ph2_coord_future_echo,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph2_coord_formatTime,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.WorkflowAppService.system.libpath": "/user/${user.name}/share/lib",
+          "oozie.service.ELService.ext.functions.coord-job-submit-data": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph1_now_echo,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph1_today_echo,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph1_yesterday_echo,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph1_currentMonth_echo,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph1_lastMonth_echo,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph1_currentYear_echo,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph1_lastYear_echo,\n      dataIn=org.apache.oozie.extensions.OozieELExtensions#ph1_dataIn_echo,\n      instanceTime=org.apache.oozie.coord.CoordELFunctions#ph1_coord_nominalTime_echo_wrap,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph1_coord_formatTime_echo,\n      dateOffset=org.apache.oozie.coord.CoordELFunctions#ph1_coord_dateOffset_echo,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.ELService.ext.functions.coord-action-create-inst": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph2_now_inst,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph2_today_inst,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph2_yesterday_inst,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_currentMonth_inst,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_lastMonth_inst,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph2_currentYear_inst,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph2_lastYear_inst,\n      latest=org.apache.oozie.coord.CoordELFunctions#ph2_coord_latest_echo,\n      future=org.apache.oozie.coord.CoordELFunctions#ph2_coord_future_echo,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph2_coord_formatTime,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.authentication.simple.anonymous.allowed": "true",
+          "oozie.systemmode": "NORMAL",
+          "oozie.service.HadoopAccessorService.supported.filesystems": "*",
+          "oozie.services": "\n      org.apache.oozie.service.SchedulerService,\n      org.apache.oozie.service.InstrumentationService,\n      org.apache.oozie.service.MemoryLocksService,\n      org.apache.oozie.service.UUIDService,\n      org.apache.oozie.service.ELService,\n      org.apache.oozie.service.AuthorizationService,\n      org.apache.oozie.service.UserGroupInformationService,\n      org.apache.oozie.service.HadoopAccessorService,\n      org.apache.oozie.service.JobsConcurrencyService,\n      org.apache.oozie.service.URIHandlerService,\n      org.apache.oozie.service.DagXLogInfoService,\n      org.apache.oozie.service.SchemaService,\n      org.apache.oozie.service.LiteWorkflowAppService,\n      org.apache.oozie.service.JPAService,\n      org.apache.oozie.service.StoreService,\n      org.apache.oozie.service.CoordinatorStoreService,\n      org.apache.oozie.service.SLAStoreService,\n      org.apache.oozie.service.DBLiteWorkflowStoreService,\n      org.apache.oozie.service.CallbackService,\n      org.apache.oozie.service.ShareLibService,\n      org.apache.oozie.service.CallableQueueService,\n      org.apache.oozie.service.ActionService,\n      org.apache.oozie.service.ActionCheckerService,\n      org.apache.oozie.service.RecoveryService,\n      org.apache.oozie.service.PurgeService,\n      org.apache.oozie.service.CoordinatorEngineService,\n      org.apache.oozie.service.BundleEngineService,\n      org.apache.oozie.service.DagEngineService,\n      org.apache.oozie.service.CoordMaterializeTriggerService,\n      org.apache.oozie.service.StatusTransitService,\n      org.apache.oozie.service.PauseTransitService,\n      org.apache.oozie.service.GroupsService,\n      org.apache.oozie.service.ProxyUserService,\n      org.apache.oozie.service.XLogStreamingService,\n      org.apache.oozie.service.JvmPauseMonitorService",
+          "oozie.service.JPAService.create.db.schema": "false",
+          "oozie.service.ELService.ext.functions.coord-action-start": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph2_now,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph2_today,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph2_yesterday,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_currentMonth,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_lastMonth,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph2_currentYear,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph2_lastYear,\n      latest=org.apache.oozie.coord.CoordELFunctions#ph3_coord_latest,\n      future=org.apache.oozie.coord.CoordELFunctions#ph3_coord_future,\n      dataIn=org.apache.oozie.extensions.OozieELExtensions#ph3_dataIn,\n      instanceTime=org.apache.oozie.coord.CoordELFunctions#ph3_coord_nominalTime,\n      dateOffset=org.apache.oozie.coord.CoordELFunctions#ph3_coord_dateOffset,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph3_coord_formatTime,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.db.schema.name": "oozie",
+          "oozie.services.ext": "org.apache.oozie.service.JMSAccessorService,org.apache.oozie.service.PartitionDependencyManagerService,org.apache.oozie.service.HCatAccessorService",
+          "oozie.service.JPAService.jdbc.driver": "org.apache.derby.jdbc.EmbeddedDriver",
+          "oozie.service.ELService.ext.functions.coord-job-submit-instances": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph1_now_echo,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph1_today_echo,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph1_yesterday_echo,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph1_currentMonth_echo,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph1_lastMonth_echo,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph1_currentYear_echo,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph1_lastYear_echo,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph1_coord_formatTime_echo,\n      latest=org.apache.oozie.coord.CoordELFunctions#ph2_coord_latest_echo,\n      future=org.apache.oozie.coord.CoordELFunctions#ph2_coord_future_echo",
+          "oozie.service.ActionService.executor.ext.classes": "\n      org.apache.oozie.action.email.EmailActionExecutor,\n      org.apache.oozie.action.hadoop.HiveActionExecutor,\n      org.apache.oozie.action.hadoop.ShellActionExecutor,\n      org.apache.oozie.action.hadoop.SqoopActionExecutor,\n      org.apache.oozie.action.hadoop.DistcpActionExecutor",
+          "oozie.service.HadoopAccessorService.hadoop.configurations": "*=/etc/hadoop/conf",
+          "oozie.service.URIHandlerService.uri.handlers": "org.apache.oozie.dependency.FSURIHandler,org.apache.oozie.dependency.HCatURIHandler"
+        }
+      }
+    },
+    {
+      "pig-env": {
+        "properties": {
+          "content": "\nJAVA_HOME={{java64_home}}\nHADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\nif [ -d \"/usr/lib/tez\" ]; then\n  PIG_OPTS=\"$PIG_OPTS -Dmapreduce.framework.name=yarn\"\nfi"
+        }
+      }
+    },
+    {
+      "pig-log4j": {
+        "properties": {
+          "content": "\n#\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n#\n#\n\n# ***** Set root logger level to DEBUG and its only appender to A.\nlog4j.logger.org.apache.pig=info, A\n\n# ***** A is set to be a ConsoleAppender.\nlog4j.appender.A=org.apache.log4j.ConsoleAppender\n# ***** A uses PatternLayout.\nlog4j.appender.A.layout=org.apache.log4j.PatternLayout\nlog4j.appender.A.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n"
+        }
+      }
+    },
+    {
+      "pig-properties": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n\n# Pig default configuration file. All values can be overwritten by pig.properties and command line arguments.\n# see bin/pig -help\n\n# brief logging (no timestamps)\nbrief=false\n\n# debug level, INFO is default\ndebug=INFO\n\n# verbose print all log messages to screen (default to print only INFO and above to screen)\nverbose=false\n\n# exectype local|mapreduce, mapreduce is default\nexectype=mapreduce\n\n# Enable insertion of information about script into hadoop job conf \npig.script.info.enabled=true\n\n# Do not spill temp files smaller than this size (bytes)\npig.spill.size.threshold=5000000\n\n# EXPERIMENT: Activate garbage collection when spilling a file bigger than this size (bytes)\n# This should help reduce the number of files being spilled.\npig.spill.gc.activation.size=40000000\n\n# the following two parameters are to help estimate the reducer number\npig.exec.reducers.bytes.per.reducer=1000000000\npig.exec.reducers.max=999\n\n# Temporary location to store the intermediate data.\npig.temp.dir=/tmp/\n\n# Threshold for merging FRJoin fragment files\npig.files.concatenation.threshold=100\npig.optimistic.files.concatenation=false;\n\npig.disable.counter=false\n\n# Avoid pig failures when multiple jobs write to the same location\npig.location.check.strict=false\n\nhcat.bin=/usr/bin/hcat"
+        }
+      }
+    },
+    {
+      "ranger-hbase-plugin-properties": {
+        "properties": {
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "REPOSITORY_CONFIG_PASSWORD": "hbase",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "policy_user": "ambari-qa",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "REPOSITORY_CONFIG_USERNAME": "hbase",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "common.name.for.certificate": "-",
+          "ranger-hbase-plugin-enabled": "No",
+          "UPDATE_XAPOLICIES_ON_GRANT_REVOKE": "true",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive"
+        }
+      }
+    },
+    {
+      "ranger-hdfs-plugin-properties": {
+        "properties": {
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "ranger-hdfs-plugin-enabled": "No",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "REPOSITORY_CONFIG_PASSWORD": "hadoop",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "policy_user": "ambari-qa",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "REPOSITORY_CONFIG_USERNAME": "hadoop",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "common.name.for.certificate": "-",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "hadoop.rpc.protection": "-",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive"
+        }
+      }
+    },
+    {
+      "ranger-hive-plugin-properties": {
+        "properties": {
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "REPOSITORY_CONFIG_PASSWORD": "hive",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "ranger-hive-plugin-enabled": "No",
+          "policy_user": "ambari-qa",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "jdbc.driverClassName": "org.apache.hive.jdbc.HiveDriver",
+          "REPOSITORY_CONFIG_USERNAME": "hive",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "common.name.for.certificate": "-",
+          "UPDATE_XAPOLICIES_ON_GRANT_REVOKE": "true",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive"
+        }
+      }
+    },
+    {
+      "ranger-knox-plugin-properties": {
+        "properties": {
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "KNOX_HOME": "/usr/hdp/current/knox-server",
+          "ranger-knox-plugin-enabled": "No",
+          "REPOSITORY_CONFIG_PASSWORD": "admin-password",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "policy_user": "ambari-qa",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "REPOSITORY_CONFIG_USERNAME": "admin",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "common.name.for.certificate": "-",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive"
+        }
+      }
+    },
+    {
+      "ranger-storm-plugin-properties": {
+        "properties": {
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "REPOSITORY_CONFIG_PASSWORD": "stormtestuser",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "policy_user": "storm",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "REPOSITORY_CONFIG_USERNAME": "stormtestuser@EXAMPLE.COM",
+          "ranger-storm-plugin-enabled": "No",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "common.name.for.certificate": "-",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive"
+        }
+      }
+    },
+    {
+      "slider-client": {
+        "properties": null
+      }
+    },
+    {
+      "slider-env": {
+        "properties": {
+          "content": "\n# Set Slider-specific environment variables here.\n\n# The only required environment variable is JAVA_HOME.  All others are\n# optional.  When running a distributed configuration it is best to\n# set JAVA_HOME in this file, so that it is correctly defined on\n# remote nodes.\n\n# The java implementation to use.  Required.\nexport JAVA_HOME={{java64_home}}\n# The hadoop conf directory.  Optional as slider-client.xml can be edited to add properties.\nexport HADOOP_CONF_DIR={{hadoop_conf_dir}}"
+        }
+      }
+    },
+    {
+      "slider-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n\n# Define some default values that can be overridden by system properties\nlog4j.rootLogger=INFO,stdout\nlog4j.threshhold=ALL\nlog4j.appender.stdout=org.apache.log4j.ConsoleAppender\nlog4j.appender.stdout.layout=org.apache.log4j.PatternLayout\n\n# log layout skips stack-trace creation operations by avoiding line numbers and method\nlog4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} - %m%n\n\n# debug edition is much more expensive\n#log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\nlog4j.appender.subprocess=org.apache.log4j.ConsoleAppender\nlog4j.appender.subprocess.layout=org.apache.log4j.PatternLayout\nlog4j.appender.subprocess.layout.ConversionPattern=[%c{1}]: %m%n\n#log4j.logger.org.apache.slider.yarn.appmaster.SliderAppMasterer.master=INFO,subprocess\n\n# for debugging Slider\n#log4j.logger.org.apache.slider=DEBUG\n#log4j.logger.org.apache.slider=DEBUG\n\n# uncomment to debug service lifecycle issues\n#log4j.logger.org.apache.hadoop.yarn.service.launcher=DEBUG\n#log4j.logger.org.apache.hadoop.yarn.service=DEBUG\n\n# uncomment for YARN operations\n#log4j.logger.org.apache.hadoop.yarn.client=DEBUG\n\n# uncomment this to debug security problems\n#log4j.logger.org.apache.hadoop.security=DEBUG\n\n#crank back on some noise\nlog4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR\nlog4j.logger.org.apache.hadoop.hdfs=WARN\n\n\nlog4j.logger.org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor=WARN\nlog4j.logger.org.apache.hadoop.yarn.server.nodemanager.NodeStatusUpdaterImpl=WARN\nlog4j.logger.org.apache.zookeeper=WARN"
+        }
+      }
+    },
+    {
+      "sqoop-env": {
+        "properties": {
+          "content": "\n# Set Hadoop-specific environment variables here.\n\n#Set path to where bin/hadoop is available\n#Set path to where bin/hadoop is available\nexport HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\n#set the path to where bin/hbase is available\nexport HBASE_HOME=${HBASE_HOME:-{{hbase_home}}}\n\n#Set the path to where bin/hive is available\nexport HIVE_HOME=${HIVE_HOME:-{{hive_home}}}\n\n#Set the path for where zookeper config dir is\nexport ZOOCFGDIR=${ZOOCFGDIR:-/etc/zookeeper/conf}\n\n# add libthrift in hive to sqoop class path first so hive imports work\nexport SQOOP_USER_CLASSPATH=\"`ls ${HIVE_HOME}/lib/libthrift-*.jar 2> /dev/null`:${SQOOP_USER_CLASSPATH}\"",
+          "sqoop_user": "sqoop"
+        }
+      }
+    },
+    {
+      "storm-env": {
+        "properties": {
+          "content": "\n#!/bin/bash\n\n# Set Storm specific environment variables here.\n\n# The java implementation to use.\nexport JAVA_HOME={{java64_home}}\n\n# export STORM_CONF_DIR=\"\"\nexport STORM_HOME=/usr/hdp/current/storm-client",
+          "storm_log_dir": "/var/log/storm",
+          "storm_user": "storm",
+          "storm_pid_dir": "/var/run/storm"
+        }
+      }
+    },
+    {
+      "storm-site": {
+        "properties": {
+          "drpc.worker.threads": "64",
+          "storm.messaging.netty.buffer_size": "5242880",
+          "topology.state.synchronization.timeout.secs": "60",
+          "topology.executor.send.buffer.size": "1024",
+          "topology.worker.childopts": "null",
+          "storm.messaging.netty.max_retries": "30",
+          "topology.receiver.buffer.size": "8",
+          "storm.messaging.netty.min_wait_ms": "100",
+          "topology.skip.missing.kryo.registrations": "false",
+          "topology.max.spout.pending": "null",
+          "topology.trident.batch.emit.interval.millis": "500",
+          "storm.zookeeper.retry.intervalceiling.millis": "30000",
+          "zmq.hwm": "0",
+          "_storm.thrift.nonsecure.transport": "backtype.storm.security.auth.SimpleTransportPlugin",
+          "topology.message.timeout.secs": "30",
+          "topology.stats.sample.rate": "0.05",
+          "topology.max.task.parallelism": "null",
+          "topology.spout.wait.strategy": "backtype.storm.spout.SleepSpoutWaitStrategy",
+          "storm.zookeeper.port": "2181",
+          "supervisor.slots.ports": "[6700, 6701]",
+          "nimbus.cleanup.inbox.freq.secs": "600",
+          "supervisor.worker.start.timeout.secs": "120",
+          "topology.kryo.factory": "backtype.storm.serialization.DefaultKryoFactory",
+          "storm.zookeeper.servers": "['%HOSTGROUP::host_group_master_1%','%HOSTGROUP::host_group_master_3%','%HOSTGROUP::host_group_master_2%']",
+          "ui.filter": "null",
+          "transactional.zookeeper.servers": "null",
+          "task.heartbeat.frequency.secs": "3",
+          "nimbus.host": "%HOSTGROUP::host_group_master_2%",
+          "storm.cluster.mode": "distributed",
+          "ui.childopts": "-Xmx768m _JAAS_PLACEHOLDER",
+          "topology.fall.back.on.java.serialization": "true",
+          "topology.disruptor.wait.strategy": "com.lmax.disruptor.BlockingWaitStrategy",
+          "topology.enable.message.timeouts": "true",
+          "logviewer.port": "8000",
+          "logviewer.appender.name": "A1",
+          "storm.local.mode.zmq": "false",
+          "ui.port": "8744",
+          "drpc.request.timeout.secs": "600",
+          "storm.zookeeper.retry.times": "5",
+          "topology.tuple.serializer": "backtype.storm.serialization.types.ListDelegateSerializer",
+          "storm.messaging.netty.max_wait_ms": "1000",
+          "storm.zookeeper.root": "/storm",
+          "topology.error.throttle.interval.secs": "10",
+          "topology.optimize": "true",
+          "topology.debug": "false",
+          "nimbus.thrift.port": "6627",
+          "nimbus.task.launch.secs": "120",
+          "topology.sleep.spout.wait.strategy.time.ms": "1",
+          "nimbus.reassign": "true",
+          "storm.zookeeper.connection.timeout": "15000",
+          "drpc.port": "3772",
+          "supervisor.heartbeat.frequency.secs": "5",
+          "zmq.threads": "1",
+          "topology.worker.shared.thread.pool.size": "4",
+          "topology.acker.executors": "null",
+          "storm.zookeeper.session.timeout": "20000",
+          "drpc.invocations.port": "3773",
+          "logviewer.childopts": "-Xmx128m _JAAS_PLACEHOLDER",
+          "java.library.path": "/usr/local/lib:/opt/local/lib:/usr/lib:/usr/hdp/current/storm-client/lib",
+          "zmq.linger.millis": "5000",
+          "nimbus.topology.validator": "backtype.storm.nimbus.DefaultTopologyValidator",
+          "nimbus.monitor.freq.secs": "10",
+          "dev.zookeeper.path": "/tmp/dev-storm-zookeeper",
+          "transactional.zookeeper.root": "/transactional",
+          "worker.heartbeat.frequency.secs": "1",
+          "nimbus.thrift.max_buffer_size": "1048576",
+          "nimbus.supervisor.timeout.secs": "60",
+          "storm.local.dir": "/mnt/hadoop/storm",
+          "task.refresh.poll.secs": "10",
+          "_storm.min.ruid": "null",
+          "topology.executor.receive.buffer.size": "1024",
+          "supervisor.worker.timeout.secs": "30",
+          "storm.zookeeper.retry.interval": "1000",
+          "topology.tick.tuple.freq.secs": "null",
+          "_storm.thrift.secure.transport": "backtype.storm.security.auth.kerberos.KerberosSaslTransportPlugin",
+          "nimbus.inbox.jar.expiration.secs": "3600",
+          "nimbus.file.copy.expiration.secs": "600",
+          "storm.messaging.netty.client_worker_threads": "1",
+          "nimbus.task.timeout.secs": "30",
+          "topology.builtin.metrics.bucket.size.secs": "60",
+          "storm.messaging.transport": "backtype.storm.messaging.netty.Context",
+          "topology.transfer.buffer.size": "1024",
+          "drpc.childopts": "-Xmx768m _JAAS_PLACEHOLDER",
+          "topology.workers": "1",
+          "drpc.queue.size": "128",
+          "transactional.zookeeper.port": "null",
+          "supervisor.monitor.frequency.secs": "3",
+          "storm.messaging.netty.server_worker_threads": "1",
+          "topology.max.error.report.per.interval": "5"
+        }
+      }
+    },
+    {
+      "tez-env": {
+        "properties": {
+          "content": "\n# Tez specific configuration\nexport TEZ_CONF_DIR={{config_dir}}\n\n# Set HADOOP_HOME to point to a specific hadoop install directory\nexport HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\n# The java implementation to use.\nexport JAVA_HOME={{java64_home}}",
+          "tez_user": "tez"
+        }
+      }
+    },
+    {
+      "tez-site": {
+        "properties": {
+          "tez.am.am-rm.heartbeat.interval-ms.max": "250",
+          "tez.am.maxtaskfailures.per.node": "10",
+          "tez.runtime.io.sort.mb": "272",
+          "tez.runtime.compress": "true",
+          "tez.am.log.level": "INFO",
+          "tez.task.launch.cluster-default.cmd-opts": "-server -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}",
+          "tez.grouping.min-size": "16777216",
+          "tez.lib.uris": "/hdp/apps/${hdp.version}/tez/tez.tar.gz",
+          "tez.am.container.reuse.non-local-fallback.enabled": "false",
+          "tez.grouping.split-waves": "1.7",
+          "tez.runtime.compress.codec": "org.apache.hadoop.io.compress.SnappyCodec",
+          "tez.generate.debug.artifacts": "false",
+          "tez.runtime.unordered.output.buffer.size-mb": "51",
+          "tez.cluster.additional.classpath.prefix": "/usr/hdp/${hdp.version}/hadoop/lib/hadoop-lzo-0.6.0.${hdp.version}.jar:/etc/hadoop/conf/secure",
+          "tez.am.container.reuse.enabled": "true",
+          "tez.task.get-task.sleep.interval-ms.max": "200",
+          "tez.grouping.max-size": "1073741824",
+          "tez.task.launch.env": "LD_LIBRARY_PATH=/usr/hdp/${hdp.version}/hadoop/lib/native:/usr/hdp/${hdp.version}/hadoop/lib/native/Linux-amd64-64",
+          "tez.session.am.dag.submit.timeout.secs": "300",
+          "tez.task.am.heartbeat.counter.interval-ms.max": "4000",
+          "tez.history.logging.service.class": "org.apache.tez.dag.history.logging.ats.ATSHistoryLoggingService",
+          "tez.task.resource.memory.mb": "682",
+          "tez.runtime.convert.user-payload.to.history-text": "false",
+          "tez.am.container.idle.release-timeout-max.millis": "20000",
+          "tez.am.launch.cmd-opts": "-XX:+PrintGCDetails -verbose:gc -XX:+PrintGCTimeStamps -XX:+UseNUMA -XX:+UseParallelGC",
+          "tez.counters.max": "2000",
+          "tez.use.cluster.hadoop-libs": "false",
+          "tez.task.launch.cmd-opts": "-XX:+PrintGCDetails -verbose:gc -XX:+PrintGCTimeStamps -XX:+UseNUMA -XX:+UseParallelGC",
+          "tez.am.launch.cluster-default.cmd-opts": "-server -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}",
+          "tez.am.container.reuse.locality.delay-allocation-millis": "250",
+          "tez.am.tez-ui.history-url.template": "__HISTORY_URL_BASE__?viewPath=%2F%23%2Ftez-app%2F__APPLICATION_ID__",
+          "tez.am.max.app.attempts": "2",
+          "tez.staging-dir": "/tmp/${user.name}/staging",
+          "tez.am.container.idle.release-timeout-min.millis": "10000",
+          "tez.am.launch.env": "LD_LIBRARY_PATH=/usr/hdp/${hdp.version}/hadoop/lib/native:/usr/hdp/${hdp.version}/hadoop/lib/native/Linux-amd64-64",
+          "tez.counters.max.groups": "1000",
+          "tez.session.client.timeout.secs": "-1",
+          "tez.am.resource.memory.mb": "1364",
+          "tez.task.max-events-per-heartbeat": "500",
+          "tez.am.container.reuse.rack-fallback.enabled": "true",
+          "tez.shuffle-vertex-manager.min-src-fraction": "0.2",
+          "tez.shuffle-vertex-manager.max-src-fraction": "0.4"
+        }
+      }
+    },
+    {
+      "topology": {
+        "properties": {
+          "content": "\n        <topology>\n\n            <gateway>\n\n                <provider>\n                    <role>authentication</role>\n                    <name>ShiroProvider</name>\n                    <enabled>true</enabled>\n                    <param>\n                        <name>sessionTimeout</name>\n                        <value>30</value>\n                    </param>\n                    <param>\n                        <name>main.ldapRealm</name>\n                        <value>org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm</value>\n                    </param>\n                    <param>\n                        <name>main.ldapRealm.userDnTemplate</name>\n                        <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>\n                    </param>\n                    <param>\n                        <name>main.ldapRealm.contextFactory.url</name>\n                        <value>ldap://{{knox_host_name}}:33389</value>\n                    </param>\n                    <param>\n                        <name>main.ldapRealm.contextFactory.authenticationMechanism</name>\n                        <value>simple</value>\n                    </param>\n                    <param>\n                        <name>urls./**</name>\n                        <value>authcBasic</value>\n                    </param>\n                </provider>\n\n                <provider>\n                    <role>identity-assertion</role>\n                    <name>Default</name>\n                    <enabled>true</enabled>\n                </provider>\n\n                <provider>\n                    <role>authorization</role>\n                    <name>AclsAuthz</name>\n                    <enabled>true</enabled>\n                </provider>\n\n            </gateway>\n\n            <service>\n                <role>NAMENODE</role>\n                <url>hdfs://{{namenode_host}}:{{namenode_rpc_port}}</url>\n            </service>\n\n            <service>\n                <role>JOBTRACKER</role>\n                <url>rpc://{{rm_host}}:{{jt_rpc_port}}</url>\n            </service>\n\n            <service>\n                <role>WEBHDFS</role>\n                <url>http://{{namenode_host}}:{{namenode_http_port}}/webhdfs</url>\n            </service>\n\n            <service>\n                <role>WEBHCAT</role>\n                <url>http://{{webhcat_server_host}}:{{templeton_port}}/templeton</url>\n            </service>\n\n            <service>\n                <role>OOZIE</role>\n                <url>http://{{oozie_server_host}}:{{oozie_server_port}}/oozie</url>\n            </service>\n\n            <service>\n                <role>WEBHBASE</role>\n                <url>http://{{hbase_master_host}}:{{hbase_master_port}}</url>\n            </service>\n\n            <service>\n                <role>HIVE</role>\n                <url>http://{{hive_server_host}}:{{hive_http_port}}/{{hive_http_path}}</url>\n            </service>\n\n            <service>\n                <role>RESOURCEMANAGER</role>\n                <url>http://{{rm_host}}:{{rm_port}}/ws</url>\n            </service>\n        </topology>"
+        }
+      }
+    },
+    {
+      "users-ldif": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nversion: 1\n\n# Please replace with site specific values\ndn: dc=hadoop,dc=apache,dc=org\nobjectclass: organization\nobjectclass: dcObject\no: Hadoop\ndc: hadoop\n\n# Entry for a sample people container\n# Please replace with site specific values\ndn: ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:organizationalUnit\nou: people\n\n# Entry for a sample end user\n# Please replace with site specific values\ndn: uid=guest,ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:person\nobjectclass:organizationalPerson\nobjectclass:inetOrgPerson\ncn: Guest\nsn: User\nuid: guest\nuserPassword:guest-password\n\n# entry for sample user admin\ndn: uid=admin,ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:person\nobjectclass:organizationalPerson\nobjectclass:inetOrgPerson\ncn: Admin\nsn: Admin\nuid: admin\nuserPassword:admin-password\n\n# entry for sample user sam\ndn: uid=sam,ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:person\nobjectclass:organizationalPerson\nobjectclass:inetOrgPerson\ncn: sam\nsn: sam\nuid: sam\nuserPassword:sam-password\n\n# entry for sample user tom\ndn: uid=tom,ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:person\nobjectclass:organizationalPerson\nobjectclass:inetOrgPerson\ncn: tom\nsn: tom\nuid: tom\nuserPassword:tom-password\n\n# create FIRST Level groups branch\ndn: ou=groups,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:organizationalUnit\nou: groups\ndescription: generic groups branch\n\n# create the analyst group under groups\ndn: cn=analyst,ou=groups,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass: groupofnames\ncn: analyst\ndescription:analyst  group\nmember: uid=sam,ou=people,dc=hadoop,dc=apache,dc=org\nmember: uid=tom,ou=people,dc=hadoop,dc=apache,dc=org\n\n\n# create the scientist group under groups\ndn: cn=scientist,ou=groups,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass: groupofnames\ncn: scientist\ndescription: scientist group\nmember: uid=sam,ou=people,dc=hadoop,dc=apache,dc=org"
+        }
+      }
+    },
+    {
+      "webhcat-env": {
+        "properties": {
+          "content": "\n# The file containing the running pid\nPID_FILE={{webhcat_pid_file}}\n\nTEMPLETON_LOG_DIR={{templeton_log_dir}}/\n\n\nWEBHCAT_LOG_DIR={{templeton_log_dir}}/\n\n# The console error log\nERROR_LOG={{templeton_log_dir}}/webhcat-console-error.log\n\n# The console log\nCONSOLE_LOG={{templeton_log_dir}}/webhcat-console.log\n\n#TEMPLETON_JAR=templeton_jar_name\n\n#HADOOP_PREFIX=hadoop_prefix\n\n#HCAT_PREFIX=hive_prefix\n\n# Set HADOOP_HOME to point to a specific hadoop install directory\nexport HADOOP_HOME={{hadoop_home}}"
+        }
+      }
+    },
+    {
+      "webhcat-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n\n# Define some default values that can be overridden by system properties\nwebhcat.root.logger = INFO, standard\nwebhcat.log.dir = .\nwebhcat.log.file = webhcat.log\n\nlog4j.rootLogger = ${webhcat.root.logger}\n\n# Logging Threshold\nlog4j.threshhold = DEBUG\n\nlog4j.appender.standard  =  org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.standard.File = ${webhcat.log.dir}/${webhcat.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern = .yyyy-MM-dd\n\nlog4j.appender.DRFA.layout = org.apache.log4j.PatternLayout\n\nlog4j.appender.standard.layout = org.apache.log4j.PatternLayout\nlog4j.appender.standard.layout.conversionPattern = %-5p | %d{DATE} | %c | %m%n\n\n# Class logging settings\nlog4j.logger.com.sun.jersey = DEBUG\nlog4j.logger.com.sun.jersey.spi.container.servlet.WebComponent = ERROR\nlog4j.logger.org.apache.hadoop = INFO\nlog4j.logger.org.apache.hadoop.conf = WARN\nlog4j.logger.org.apache.zookeeper = WARN\nlog4j.logger.org.eclipse.jetty = INFO"
+        }
+      }
+    },
+    {
+      "webhcat-site": {
+        "properties": {
+          "templeton.hcat": "/usr/hdp/current/hive-client/bin/hcat",
+          "templeton.storage.class": "org.apache.hive.hcatalog.templeton.tool.ZooKeeperStorage",
+          "templeton.jar": "/usr/hdp/current/hive-webhcat/share/webhcat/svr/lib/hive-webhcat-*.jar",
+          "templeton.sqoop.path": "sqoop.tar.gz/sqoop/bin/sqoop",
+          "templeton.streaming.jar": "hdfs:///hdp/apps/${hdp.version}/mapreduce/hadoop-streaming.jar",
+          "templeton.pig.path": "pig.tar.gz/pig/bin/pig",
+          "templeton.exec.timeout": "60000",
+          "templeton.hive.properties": "hive.metastore.local=false,hive.metastore.uris=thrift://%HOSTGROUP::host_group_master_2%:9083,hive.metastore.sasl.enabled=false,hive.metastore.execute.setugi=true",
+          "templeton.override.enabled": "false",
+          "templeton.hive.archive": "hdfs:///hdp/apps/${hdp.version}/hive/hive.tar.gz",
+          "templeton.port": "50111",
+          "templeton.sqoop.home": "sqoop.tar.gz/sqoop",
+          "templeton.hadoop": "/usr/hdp/current/hadoop-client/bin/hadoop",
+          "templeton.libjars": "/usr/hdp/current/zookeeper-client/zookeeper.jar",
+          "templeton.hive.home": "hive.tar.gz/hive",
+          "templeton.pig.archive": "hdfs:///hdp/apps/${hdp.version}/pig/pig.tar.gz",
+          "templeton.zookeeper.hosts": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181",
+          "templeton.hcat.home": "hive.tar.gz/hive/hcatalog",
+          "templeton.hadoop.conf.dir": "/etc/hadoop/conf",
+          "templeton.hive.path": "hive.tar.gz/hive/bin/hive",
+          "templeton.sqoop.archive": "hdfs:///hdp/apps/${hdp.version}/sqoop/sqoop.tar.gz"
+        }
+      }
+    },
+    {
+      "yarn-env": {
+        "properties": {
+          "yarn_log_dir_prefix": "/var/log/hadoop-yarn",
+          "resourcemanager_heapsize": "1024",
+          "content": "\nexport HADOOP_YARN_HOME={{hadoop_yarn_home}}\nexport YARN_LOG_DIR={{yarn_log_dir_prefix}}/$USER\nexport YARN_PID_DIR={{yarn_pid_dir_prefix}}/$USER\nexport HADOOP_LIBEXEC_DIR={{hadoop_libexec_dir}}\nexport JAVA_HOME={{java64_home}}\n\n# User for YARN daemons\nexport HADOOP_YARN_USER=${HADOOP_YARN_USER:-yarn}\n\n# resolve links - $0 may be a softlink\nexport YARN_CONF_DIR=\"${YARN_CONF_DIR:-$HADOOP_YARN_HOME/conf}\"\n\n# some Java parameters\n# export JAVA_HOME=/home/y/libexec/jdk1.6.0/\nif [ \"$JAVA_HOME\" != \"\" ]; then\n  #echo \"run java in $JAVA_HOME\"\n  JAVA_HOME=$JAVA_HOME\nfi\n\nif [ \"$JAVA_HOME\" = \"\" ]; then\n  echo \"Error: JAVA_HOME is not set.\"\n  exit 1\nfi\n\nJAVA=$JAVA_HOME/bin/java\nJAVA_HEAP_MAX=-Xmx1000m\n\n# For setting YARN specific HEAP sizes please use this\n# Parameter and set appropriately\nYARN_HEAPSIZE={{yarn_heapsize}}\n\n# check envvars which might override default args\nif [ \"$YARN_HEAPSIZE\" != \"\" ]; then\n  JAVA_HEAP_MAX=\"-Xmx\"\"$YARN_HEAPSIZE\"\"m\"\nfi\n\n# Resource Manager specific parameters\n\n# Specify the max Heapsize for the ResourceManager using a numerical value\n# in the scale of MB. For example, to specify an jvm option of -Xmx1000m, set\n# the value to 1000.\n# This value will be overridden by an Xmx setting specified in either YARN_OPTS\n# and/or YARN_RESOURCEMANAGER_OPTS.\n# If not specified, the default value will be picked from either YARN_HEAPMAX\n# or JAVA_HEAP_MAX with YARN_HEAPMAX as the preferred option of the two.\nexport YARN_RESOURCEMANAGER_HEAPSIZE={{resourcemanager_heapsize}}\n\n# Specify the JVM options to be used when starting the ResourceManager.\n# These options will be appended to the options specified as YARN_OPTS\n# and therefore may override any similar flags set in YARN_OPTS\n#export YARN_RESOURCEMANAGER_OPTS=\n\n# Node Manager specific parameters\n\n# Specify the max Heapsize for the NodeManager using a numerical value\n# in the scale of MB. For example, to specify an jvm option of -Xmx1000m, set\n# the value to 1000.\n# This value will be overridden by an Xmx setting specified in either YARN_OPTS\n# and/or YARN_NODEMANAGER_OPTS.\n# If not specified, the default value will be picked from either YARN_HEAPMAX\n# or JAVA_HEAP_MAX with YARN_HEAPMAX as the preferred option of the two.\nexport YARN_NODEMANAGER_HEAPSIZE={{nodemanager_heapsize}}\n\n# Specify the max Heapsize for the HistoryManager using a numerical value\n# in the scale of MB. For example, to specify an jvm option of -Xmx1000m, set\n# the value to 1024.\n# This value will be overridden by an Xmx setting specified in either YARN_OPTS\n# and/or YARN_HISTORYSERVER_OPTS.\n# If not specified, the default value will be picked from either YARN_HEAPMAX\n# or JAVA_HEAP_MAX with YARN_HEAPMAX as the preferred option of the two.\nexport YARN_HISTORYSERVER_HEAPSIZE={{apptimelineserver_heapsize}}\n\n# Specify the JVM options to be used when starting the NodeManager.\n# These options will be appended to the options specified as YARN_OPTS\n# and therefore may override any similar flags set in YARN_OPTS\n#export YARN_NODEMANAGER_OPTS=\n\n# so that filenames w/ spaces are handled correctly in loops below\nIFS=\n\n\n# default log directory and file\nif [ \"$YARN_LOG_DIR\" = \"\" ]; then\n  YARN_LOG_DIR=\"$HADOOP_YARN_HOME/logs\"\nfi\nif [ \"$YARN_LOGFILE\" = \"\" ]; then\n  YARN_LOGFILE='yarn.log'\nfi\n\n# default policy file for service-level authorization\nif [ \"$YARN_POLICYFILE\" = \"\" ]; then\n  YARN_POLICYFILE=\"hadoop-policy.xml\"\nfi\n\n# restore ordinary behaviour\nunset IFS\n\n\nYARN_OPTS=\"$YARN_OPTS -Dhadoop.log.dir=$YARN_LOG_DIR\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.log.dir=$YARN_LOG_DIR\"\nYARN_OPTS=\"$YARN_OPTS -Dhadoop.log.file=$YARN_LOGFILE\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.log.file=$YARN_LOGFILE\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.home.dir=$YARN_COMMON_HOME\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.id.str=$YARN_IDENT_STRING\"\nYARN_OPTS=\"$YARN_OPTS -Dhadoop.root.logger=${YARN_ROOT_LOGGER:-INFO,console}\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.root.logger=${YARN_ROOT_LOGGER:-INFO,console}\"\nif [ \"x$JAVA_LIBRARY_PATH\" != \"x\" ]; then\n  YARN_OPTS=\"$YARN_OPTS -Djava.library.path=$JAVA_LIBRARY_PATH\"\nfi\nYARN_OPTS=\"$YARN_OPTS -Dyarn.policy.file=$YARN_POLICYFILE\"",
+          "yarn_user": "yarn",
+          "yarn_pid_dir_prefix": "/var/run/hadoop-yarn",
+          "nodemanager_heapsize": "1024",
+          "min_user_id": "500",
+          "yarn_heapsize": "1024",
+          "apptimelineserver_heapsize": "1024"
+        }
+      }
+    },
+    {
+      "yarn-log4j": {
+        "properties": {
+          "content": "\n#Relative to Yarn Log Dir Prefix\nyarn.log.dir=.\n#\n# Job Summary Appender\n#\n# Use following logger to send summary to separate file defined by\n# hadoop.mapreduce.jobsummary.log.file rolled daily:\n# hadoop.mapreduce.jobsummary.logger=INFO,JSA\n#\nhadoop.mapreduce.jobsummary.logger=${hadoop.root.logger}\nhadoop.mapreduce.jobsummary.log.file=hadoop-mapreduce.jobsummary.log\nlog4j.appender.JSA=org.apache.log4j.DailyRollingFileAppender\n# Set the ResourceManager summary log filename\nyarn.server.resourcemanager.appsummary.log.file=hadoop-mapreduce.jobsummary.log\n# Set the ResourceManager summary log level and appender\nyarn.server.resourcemanager.appsummary.logger=${hadoop.root.logger}\n#yarn.server.resourcemanager.appsummary.logger=INFO,RMSUMMARY\n\n# To enable AppSummaryLogging for the RM,\n# set yarn.server.resourcemanager.appsummary.logger to\n# LEVEL,RMSUMMARY in hadoop-env.sh\n\n# Appender for ResourceManager Application Summary Log\n# Requires the following properties to be set\n#    - hadoop.log.dir (Hadoop Log directory)\n#    - yarn.server.resourcemanager.appsummary.log.file (resource manager app summary log filename)\n#    - yarn.server.resourcemanager.appsummary.logger (resource manager app summary log level and appender)\nlog4j.appender.RMSUMMARY=org.apache.log4j.RollingFileAppender\nlog4j.appender.RMSUMMARY.File=${yarn.log.dir}/${yarn.server.resourcemanager.appsummary.log.file}\nlog4j.appender.RMSUMMARY.MaxFileSize=256MB\nlog4j.appender.RMSUMMARY.MaxBackupIndex=20\nlog4j.appender.RMSUMMARY.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RMSUMMARY.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n\nlog4j.appender.JSA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.JSA.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\nlog4j.appender.JSA.DatePattern=.yyyy-MM-dd\nlog4j.appender.JSA.layout=org.apache.log4j.PatternLayout\nlog4j.logger.org.apache.hadoop.yarn.server.resourcemanager.RMAppManager$ApplicationSummary=${yarn.server.resourcemanager.appsummary.logger}\nlog4j.additivity.org.apache.hadoop.yarn.server.resourcemanager.RMAppManager$ApplicationSummary=false"
+        }
+      }
+    },
+    {
+      "yarn-site": {
+        "properties": {
+          "yarn.nodemanager.linux-container-executor.group": "hadoop",
+          "yarn.timeline-service.client.retry-interval-ms": "1000",
+          "yarn.timeline-service.address": "%HOSTGROUP::host_group_master_3%:10200",
+          "yarn.nodemanager.container-executor.class": "org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor",
+          "yarn.nodemanager.recovery.enabled": "true",
+          "yarn.nodemanager.vmem-check-enabled": "false",
+          "yarn.nodemanager.recovery.dir": "{{yarn_log_dir_prefix}}/nodemanager/recovery-state",
+          "yarn.resourcemanager.connect.retry-interval.ms": "30000",
+          "yarn.nodemanager.log-aggregation.num-log-files-per-app": "30",
+          "yarn.timeline-service.leveldb-timeline-store.path": "/mnt/hadoop/yarn/timeline",
+          "yarn.resourcemanager.connect.max-wait.ms": "900000",
+          "yarn.timeline-service.enabled": "true",
+          "yarn.nodemanager.log.retain-second": "604800",
+          "yarn.resourcemanager.zk-acl": "world:anyone:rwcda",
+          "yarn.resourcemanager.work-preserving-recovery.scheduling-wait-ms": "10000",
+          "yarn.resourcemanager.webapp.address": "%HOSTGROUP::host_group_master_2%:8088",
+          "yarn.resourcemanager.store.class": "org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore",
+          "yarn.node-labels.fs-store.root-dir": "/system/yarn/node-labels",
+          "yarn.nodemanager.linux-container-executor.cgroups.mount": "false",
+          "yarn.nodemanager.health-checker.interval-ms": "135000",
+          "yarn.nodemanager.vmem-pmem-ratio": "2.1",
+          "yarn.timeline-service.generic-application-history.store-class": "org.apache.hadoop.yarn.server.applicationhistoryservice.NullApplicationHistoryStore",
+          "yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage": "90",
+          "yarn.log.server.url": "http://%HOSTGROUP::host_group_master_1%:19888/jobhistory/logs",
+          "yarn.nodemanager.linux-container-executor.cgroups.hierarchy": "hadoop-yarn",
+          "yarn.nodemanager.resource.memory-mb": "2048",
+          "yarn.nodemanager.resource.cpu-vcores": "1",
+          "yarn.nodemanager.log-aggregation.roll-monitoring-interval-seconds": "-1",
+          "yarn.resourcemanager.zk-retry-interval-ms": "1000",
+          "yarn.nodemanager.disk-health-checker.min-healthy-disks": "0.25",
+          "yarn.resourcemanager.work-preserving-recovery.enabled": "true",
+          "yarn.http.policy": "HTTP_ONLY",
+          "yarn.resourcemanager.zk-num-retries": "1000",
+          "yarn.nodemanager.log-aggregation.debug-enabled": "false",
+          "yarn.nodemanager.remote-app-log-dir": "/app-logs",
+          "yarn.timeline-service.webapp.address": "%HOSTGROUP::host_group_master_3%:8188",
+          "yarn.nodemanager.aux-services": "mapreduce_shuffle",
+          "yarn.timeline-service.webapp.https.address": "%HOSTGROUP::host_group_master_3%:8190",
+          "yarn.node-labels.fs-store.retry-policy-spec": "2000, 500",
+          "yarn.timeline-service.client.max-retries": "30",
+          "yarn.resourcemanager.webapp.https.address": "%HOSTGROUP::host_group_master_2%:8090",
+          "yarn.timeline-service.ttl-ms": "2678400000",
+          "yarn.resourcemanager.scheduler.class": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler",
+          "yarn.nodemanager.remote-app-log-dir-suffix": "logs",
+          "yarn.nodemanager.log-dirs": "/mnt/hadoop/yarn/log",
+          "yarn.resourcemanager.fs.state-store.uri": " ",
+          "yarn.client.nodemanager-connect.max-wait-ms": "60000",
+          "yarn.acl.enable": "false",
+          "yarn.resourcemanager.bind-host": "0.0.0.0",
+          "yarn.resourcemanager.admin.address": "%HOSTGROUP::host_group_master_2%:8141",
+          "yarn.resourcemanager.ha.enabled": "false",
+          "yarn.timeline-service.store-class": "org.apache.hadoop.yarn.server.timeline.LeveldbTimelineStore",
+          "yarn.timeline-service.bind-host": "0.0.0.0",
+          "yarn.resourcemanager.resource-tracker.address": "%HOSTGROUP::host_group_master_2%:8025",
+          "yarn.timeline-service.ttl-enable": "true",
+          "yarn.resourcemanager.scheduler.address": "%HOSTGROUP::host_group_master_2%:8030",
+          "yarn.resourcemanager.nodes.exclude-path": "/etc/hadoop/conf/yarn.exclude",
+          "yarn.nodemanager.linux-container-executor.resources-handler.class": "org.apache.hadoop.yarn.server.nodemanager.util.DefaultLCEResourcesHandler",
+          "hadoop.registry.rm.enabled": "true",
+          "yarn.resourcemanager.state-store.max-completed-applications": "${yarn.resourcemanager.max-completed-applications}",
+          "yarn.timeline-service.http-authentication.simple.anonymous.allowed": "true",
+          "yarn.resourcemanager.fs.state-store.retry-policy-spec": "2000, 500",
+          "yarn.nodemanager.local-dirs": "/mnt/hadoop/yarn/local",
+          "yarn.nodemanager.bind-host": "0.0.0.0",
+          "yarn.admin.acl": "",
+          "yarn.resourcemanager.address": "%HOSTGROUP::host_group_master_2%:8050",
+          "yarn.timeline-service.leveldb-timeline-store.start-time-write-cache-size": "10000",
+          "yarn.resourcemanager.system-metrics-publisher.dispatcher.pool-size": "10",
+          "yarn.resourcemanager.recovery.enabled": "true",
+          "yarn.node-labels.manager-class": "org.apache.hadoop.yarn.server.resourcemanager.nodelabels.MemoryRMNodeLabelsManager",
+          "yarn.application.classpath": "$HADOOP_CONF_DIR,/usr/hdp/current/hadoop-client/*,/usr/hdp/current/hadoop-client/lib/*,/usr/hdp/current/hadoop-hdfs-client/*,/usr/hdp/current/hadoop-hdfs-client/lib/*,/usr/hdp/current/hadoop-yarn-client/*,/usr/hdp/current/hadoop-yarn-client/lib/*",
+          "yarn.resourcemanager.webapp.delegation-token-auth-filter.enabled": "false",
+          "yarn.scheduler.minimum-allocation-mb": "682",
+          "yarn.log-aggregation-enable": "true",
+          "yarn.nodemanager.delete.debug-delay-sec": "0",
+          "yarn.nodemanager.admin-env": "MALLOC_ARENA_MAX=$MALLOC_ARENA_MAX",
+          "yarn.timeline-service.http-authentication.type": "simple",
+          "yarn.log-aggregation.retain-seconds": "2592000",
+          "yarn.nodemanager.linux-container-executor.cgroups.strict-resource-usage": "false",
+          "hadoop.registry.zk.quorum": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181",
+          "yarn.resourcemanager.am.max-attempts": "2",
+          "yarn.nodemanager.address": "0.0.0.0:45454",
+          "yarn.scheduler.maximum-allocation-mb": "2048",
+          "yarn.resourcemanager.hostname": "%HOSTGROUP::host_group_master_2%",
+          "yarn.nodemanager.resource.percentage-physical-cpu-limit": "100",
+          "yarn.timeline-service.leveldb-timeline-store.read-cache-size": "104857600",
+          "yarn.resourcemanager.zk-state-store.parent-path": "/rmstore",
+          "yarn.resourcemanager.zk-timeout-ms": "10000",
+          "yarn.nodemanager.aux-services.mapreduce_shuffle.class": "org.apache.hadoop.mapred.ShuffleHandler",
+          "yarn.nodemanager.container-monitor.interval-ms": "3000",
+          "yarn.timeline-service.leveldb-timeline-store.start-time-read-cache-size": "10000",
+          "yarn.timeline-service.leveldb-timeline-store.ttl-interval-ms": "300000",
+          "yarn.nodemanager.health-checker.script.timeout-ms": "60000",
+          "yarn.client.nodemanager-connect.retry-interval-ms": "10000",
+          "yarn.nodemanager.disk-health-checker.min-free-space-per-disk-mb": "1000",
+          "yarn.nodemanager.log-aggregation.compression-type": "gz",
+          "yarn.resourcemanager.system-metrics-publisher.enabled": "true"
+        }
+      }
+    },
+    {
+      "zoo.cfg": {
+        "properties": {
+          "initLimit": "10",
+          "clientPort": "2181",
+          "autopurge.snapRetainCount": "30",
+          "tickTime": "2000",
+          "syncLimit": "5",
+          "autopurge.purgeInterval": "24",
+          "dataDir": "/hadoopfs/fs1/zookeeper"
+        }
+      }
+    },
+    {
+      "zookeeper-env": {
+        "properties": {
+          "zk_log_dir": "/var/log/zookeeper",
+          "content": "\nexport JAVA_HOME={{java64_home}}\nexport ZOOKEEPER_HOME={{zk_home}}\nexport ZOO_LOG_DIR={{zk_log_dir}}\nexport ZOOPIDFILE={{zk_pid_file}}\nexport SERVER_JVMFLAGS={{zk_server_heapsize}}\nexport JAVA=$JAVA_HOME/bin/java\nexport CLASSPATH=$CLASSPATH:/usr/share/zookeeper/*\n\n{% if security_enabled %}\nexport SERVER_JVMFLAGS=\"$SERVER_JVMFLAGS -Djava.security.auth.login.config={{zk_server_jaas_file}}\"\nexport CLIENT_JVMFLAGS=\"$CLIENT_JVMFLAGS -Djava.security.auth.login.config={{zk_client_jaas_file}}\"\n{% endif %}",
+          "zk_pid_dir": "/var/run/zookeeper",
+          "zk_user": "zookeeper"
+        }
+      }
+    },
+    {
+      "zookeeper-log4j": {
+        "properties": {
+          "content": "\n#\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n#\n#\n\n#\n# ZooKeeper Logging Configuration\n#\n\n# DEFAULT: console appender only\nlog4j.rootLogger=INFO, CONSOLE\n\n# Example with rolling log file\n#log4j.rootLogger=DEBUG, CONSOLE, ROLLINGFILE\n\n# Example with rolling log file and tracing\n#log4j.rootLogger=TRACE, CONSOLE, ROLLINGFILE, TRACEFILE\n\n#\n# Log INFO level and above messages to the console\n#\nlog4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\nlog4j.appender.CONSOLE.Threshold=INFO\nlog4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\nlog4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n\n\n#\n# Add ROLLINGFILE to rootLogger to get log file output\n#    Log DEBUG level and above messages to a log file\nlog4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender\nlog4j.appender.ROLLINGFILE.Threshold=DEBUG\nlog4j.appender.ROLLINGFILE.File=zookeeper.log\n\n# Max log file size of 10MB\nlog4j.appender.ROLLINGFILE.MaxFileSize=10MB\n# uncomment the next line to limit number of backup files\n#log4j.appender.ROLLINGFILE.MaxBackupIndex=10\n\nlog4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout\nlog4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n\n\n\n#\n# Add TRACEFILE to rootLogger to get log file output\n#    Log DEBUG level and above messages to a log file\nlog4j.appender.TRACEFILE=org.apache.log4j.FileAppender\nlog4j.appender.TRACEFILE.Threshold=TRACE\nlog4j.appender.TRACEFILE.File=zookeeper_trace.log\n\nlog4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout\n### Notice we are including log4j's NDC here (%x)\nlog4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L][%x] - %m%n"
+        }
+      }
+    }
+  ],
+  "host_groups": [
+    {
+      "name": "host_group_slave_1",
+      "configurations": [
+
+      ],
+      "components": [
+        {
+          "name": "HBASE_REGIONSERVER"
+        },
+        {
+          "name": "NODEMANAGER"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "DATANODE"
+        }
+      ],
+      "cardinality": "3"
+    },
+    {
+      "name": "host_group_slave_2",
+      "configurations": [
+
+      ],
+      "components": [
+        {
+          "name": "KAFKA_BROKER"
+        },
+        {
+          "name": "SUPERVISOR"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        }
+      ],
+      "cardinality": "3"
+    },
+    {
+      "name": "host_group_master_3",
+      "configurations": [
+
+      ],
+      "components": [
+        {
+          "name": "ZOOKEEPER_SERVER"
+        },
+        {
+          "name": "APP_TIMELINE_SERVER"
+        },
+        {
+          "name": "HBASE_MASTER"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "SECONDARY_NAMENODE"
+        },
+        {
+          "name": "DRPC_SERVER"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "host_group_master_2",
+      "configurations": [
+
+      ],
+      "components": [
+        {
+          "name": "ZOOKEEPER_SERVER"
+        },
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        },
+        {
+          "name": "PIG"
+        },
+        {
+          "name": "STORM_UI_SERVER"
+        },
+        {
+          "name": "HIVE_SERVER"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "TEZ_CLIENT"
+        },
+        {
+          "name": "HIVE_METASTORE"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "YARN_CLIENT"
+        },
+        {
+          "name": "MAPREDUCE2_CLIENT"
+        },
+        {
+          "name": "MYSQL_SERVER"
+        },
+        {
+          "name": "NIMBUS"
+        },
+        {
+          "name": "RESOURCEMANAGER"
+        },
+        {
+          "name": "WEBHCAT_SERVER"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "host_group_master_1",
+      "configurations": [
+
+      ],
+      "components": [
+        {
+          "name": "ZOOKEEPER_SERVER"
+        },
+        {
+          "name": "HISTORYSERVER"
+        },
+        {
+          "name": "OOZIE_CLIENT"
+        },
+        {
+          "name": "NAMENODE"
+        },
+        {
+          "name": "OOZIE_SERVER"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "YARN_CLIENT"
+        },
+        {
+          "name": "FALCON_SERVER"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "MAPREDUCE2_CLIENT"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "host_group_client_1",
+      "configurations": [
+
+      ],
+      "components": [
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        },
+        {
+          "name": "PIG"
+        },
+        {
+          "name": "OOZIE_CLIENT"
+        },
+        {
+          "name": "HBASE_CLIENT"
+        },
+        {
+          "name": "HCAT"
+        },
+        {
+          "name": "KNOX_GATEWAY"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "FALCON_CLIENT"
+        },
+        {
+          "name": "TEZ_CLIENT"
+        },
+        {
+          "name": "SLIDER"
+        },
+        {
+          "name": "SQOOP"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "HIVE_CLIENT"
+        },
+        {
+          "name": "YARN_CLIENT"
+        },
+        {
+          "name": "METRICS_COLLECTOR"
+        },
+        {
+          "name": "FLUME_HANDLER"
+        },
+        {
+          "name": "MAPREDUCE2_CLIENT"
+        }
+      ],
+      "cardinality": "1"
+    }
+  ]
+}

--- a/src/test/resources/hdp-streaming.json
+++ b/src/test/resources/hdp-streaming.json
@@ -1,0 +1,1747 @@
+{
+  "configurations": [
+    {
+      "ams-env": {
+        "properties": {
+          "ambari_metrics_user": "ams",
+          "content": "\n# Set environment variables here.\n\n# The java implementation to use. Java 1.6 required.\nexport JAVA_HOME={{java64_home}}\n\n# Collector Log directory for log4j\nexport AMS_COLLECTOR_LOG_DIR={{ams_collector_log_dir}}\n\n# Monitor Log directory for outfile\nexport AMS_MONITOR_LOG_DIR={{ams_monitor_log_dir}}\n\n# Collector pid directory\nexport AMS_COLLECTOR_PID_DIR={{ams_collector_pid_dir}}\n\n# Monitor pid directory\nexport AMS_MONITOR_PID_DIR={{ams_monitor_pid_dir}}\n\n# AMS HBase pid directory\nexport AMS_HBASE_PID_DIR={{hbase_pid_dir}}\n\n# AMS Collector heapsize\nexport AMS_COLLECTOR_HEAPSIZE={{metrics_collector_heapsize}}\n\n# AMS Collector options\nexport AMS_COLLECTOR_OPTS=\"-Djava.library.path=/usr/lib/ams-hbase/lib/hadoop-native -Xmx$AMS_COLLECTOR_HEAPSIZE \"\n{% if security_enabled %}\nexport AMS_COLLECTOR_OPTS=\"$AMS_COLLECTOR_OPTS -Djava.security.auth.login.config={{ams_collector_jaas_config_file}}\"\n{% endif %}",
+          "metrics_collector_heapsize": "512m",
+          "metrics_collector_log_dir": "/var/log/ambari-metrics-collector",
+          "metrics_collector_pid_dir": "/var/run/ambari-metrics-collector",
+          "metrics_monitor_log_dir": "/var/log/ambari-metrics-monitor",
+          "metrics_monitor_pid_dir": "/var/run/ambari-metrics-monitor"
+        }
+      }
+    },
+    {
+      "ams-hbase-env": {
+        "properties": {
+          "content": "\n# Set environment variables here.\n\n# The java implementation to use. Java 1.6 required.\nexport JAVA_HOME={{java64_home}}\n\n# HBase Configuration directory\nexport HBASE_CONF_DIR=${HBASE_CONF_DIR:-{{hbase_conf_dir}}}\n\n# Extra Java CLASSPATH elements. Optional.\nexport HBASE_CLASSPATH=${HBASE_CLASSPATH}\n\n# The maximum amount of heap to use, in MB. Default is 1000. Master heap size.\nexport HBASE_HEAPSIZE={{hbase_heapsize}}\n\n# Extra Java runtime options.\n# Below are what we set by default. May only work with SUN JVM.\n# For more on why as well as other possible settings,\n# see http://wiki.apache.org/hadoop/PerformanceTuning\nexport HBASE_OPTS=\"-XX:+UseConcMarkSweepGC -XX:ErrorFile={{hbase_log_dir}}/hs_err_pid%p.log -Djava.io.tmpdir={{hbase_tmp_dir}}\"\nexport SERVER_GC_OPTS=\"-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:{{hbase_log_dir}}/gc.log-`date +'%Y%m%d%H%M'`\"\n# Uncomment below to enable java garbage collection logging.\n# export HBASE_OPTS=\"$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$HBASE_HOME/logs/gc-hbase.log\"\n\n# Uncomment and adjust to enable JMX exporting\n# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.\n# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html\n#\n# export HBASE_JMX_BASE=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\"\nexport HBASE_MASTER_OPTS=\" -XX:PermSize=64m -XX:MaxPermSize={{hbase_master_maxperm_size}} -Xms{{hbase_heapsize}} -Xmx{{hbase_heapsize}} -Xmn{{hbase_master_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly\"\nexport HBASE_REGIONSERVER_OPTS=\"-XX:MaxPermSize=128m -Xmn{{regionserver_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -Xms{{regionserver_heapsize}} -Xmx{{regionserver_heapsize}}\"\n# export HBASE_THRIFT_OPTS=\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103\"\n# export HBASE_ZOOKEEPER_OPTS=\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104\"\n\n# File naming hosts on which HRegionServers will run. $HBASE_HOME/conf/regionservers by default.\nexport HBASE_REGIONSERVERS=${HBASE_CONF_DIR}/regionservers\n\n# Extra ssh options. Empty by default.\n# export HBASE_SSH_OPTS=\"-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR\"\n\n# Where log files are stored. $HBASE_HOME/logs by default.\nexport HBASE_LOG_DIR={{hbase_log_dir}}\n\n# A string representing this instance of hbase. $USER by default.\n# export HBASE_IDENT_STRING=$USER\n\n# The scheduling priority for daemon processes. See 'man nice'.\n# export HBASE_NICENESS=10\n\n# The directory where pid files are stored. /tmp by default.\nexport HBASE_PID_DIR={{hbase_pid_dir}}\n\n# Seconds to sleep between slave commands. Unset by default. This\n# can be useful in large clusters, where, e.g., slave rsyncs can\n# otherwise arrive faster than the master can service them.\n# export HBASE_SLAVE_SLEEP=0.1\n\n# Tell HBase whether it should manage it's own instance of Zookeeper or not.\nexport HBASE_MANAGES_ZK=false\n\n{% if security_enabled %}\nexport HBASE_OPTS=\"$HBASE_OPTS -Djava.security.auth.login.config={{client_jaas_config_file}}\"\nexport HBASE_MASTER_OPTS=\"$HBASE_MASTER_OPTS -Djava.security.auth.login.config={{master_jaas_config_file}}\"\nexport HBASE_REGIONSERVER_OPTS=\"$HBASE_REGIONSERVER_OPTS -Djava.security.auth.login.config={{regionserver_jaas_config_file}}\"\nexport HBASE_ZOOKEEPER_OPTS=\"$HBASE_ZOOKEEPER_OPTS -Djava.security.auth.login.config={{ams_zookeeper_jaas_config_file}}\"\n{% endif %}\n\n# use embedded native libs\n_HADOOP_NATIVE_LIB=\"/usr/lib/ams-hbase/lib/hadoop-native/\"\nexport HBASE_OPTS=\"$HBASE_OPTS -Djava.library.path=${_HADOOP_NATIVE_LIB}\"\n\n# Unset HADOOP_HOME to avoid importing HADOOP installed cluster related configs like: /usr/hdp/2.2.0.0-2041/hadoop/conf/\nexport HADOOP_HOME={{ams_hbase_home_dir}}",
+          "hbase_log_dir": "/var/log/ambari-metrics-collector",
+          "hbase_master_heapsize": "1024m",
+          "hbase_master_maxperm_size": "128m",
+          "hbase_master_xmn_size": "128m",
+          "hbase_pid_dir": "/var/run/ambari-metrics-collector/",
+          "hbase_regionserver_heapsize": "1024m",
+          "hbase_regionserver_xmn_max": "512m",
+          "hbase_regionserver_xmn_ratio": "0.2",
+          "regionserver_xmn_size": "256m"
+        }
+      }
+    },
+    {
+      "ams-hbase-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n\n# Define some default values that can be overridden by system properties\nhbase.root.logger=INFO,console\nhbase.security.logger=INFO,console\nhbase.log.dir=.\nhbase.log.file=hbase.log\n\n# Define the root logger to the system property \"hbase.root.logger\".\nlog4j.rootLogger=${hbase.root.logger}\n\n# Logging Threshold\nlog4j.threshold=ALL\n\n#\n# Daily Rolling File Appender\n#\nlog4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFA.File=${hbase.log.dir}/${hbase.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern=.yyyy-MM-dd\n\n# 30-day backup\n#log4j.appender.DRFA.MaxBackupIndex=30\nlog4j.appender.DRFA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\nlog4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n# Rolling File Appender properties\nhbase.log.maxfilesize=256MB\nhbase.log.maxbackupindex=20\n\n# Rolling File Appender\nlog4j.appender.RFA=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFA.File=${hbase.log.dir}/${hbase.log.file}\n\nlog4j.appender.RFA.MaxFileSize=${hbase.log.maxfilesize}\nlog4j.appender.RFA.MaxBackupIndex=${hbase.log.maxbackupindex}\n\nlog4j.appender.RFA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n#\n# Security audit appender\n#\nhbase.security.log.file=SecurityAuth.audit\nhbase.security.log.maxfilesize=256MB\nhbase.security.log.maxbackupindex=20\nlog4j.appender.RFAS=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFAS.File=${hbase.log.dir}/${hbase.security.log.file}\nlog4j.appender.RFAS.MaxFileSize=${hbase.security.log.maxfilesize}\nlog4j.appender.RFAS.MaxBackupIndex=${hbase.security.log.maxbackupindex}\nlog4j.appender.RFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.category.SecurityLogger=${hbase.security.logger}\nlog4j.additivity.SecurityLogger=false\n#log4j.logger.SecurityLogger.org.apache.hadoop.hbase.security.access.AccessController=TRACE\n\n#\n# Null Appender\n#\nlog4j.appender.NullAppender=org.apache.log4j.varia.NullAppender\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n# Custom Logging levels\n\nlog4j.logger.org.apache.zookeeper=INFO\n#log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG\nlog4j.logger.org.apache.hadoop.hbase=INFO\n# Make these two classes INFO-level. Make them DEBUG to see more zk debug.\nlog4j.logger.org.apache.hadoop.hbase.zookeeper.ZKUtil=INFO\nlog4j.logger.org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher=INFO\n#log4j.logger.org.apache.hadoop.dfs=DEBUG\n# Set this class to log INFO only otherwise its OTT\n# Enable this to get detailed connection error/retry logging.\n# log4j.logger.org.apache.hadoop.hbase.client.HConnectionManager$HConnectionImplementation=TRACE\n\n\n# Uncomment this line to enable tracing on _every_ RPC call (this can be a lot of output)\n#log4j.logger.org.apache.hadoop.ipc.HBaseServer.trace=DEBUG\n\n# Uncomment the below if you want to remove logging of client region caching'\n# and scan of .META. messages\n# log4j.logger.org.apache.hadoop.hbase.client.HConnectionManager$HConnectionImplementation=INFO\n# log4j.logger.org.apache.hadoop.hbase.client.MetaScanner=INFO"
+        }
+      }
+    },
+    {
+      "ams-hbase-policy": {
+        "properties": {
+          "security.admin.protocol.acl": "*",
+          "security.client.protocol.acl": "*",
+          "security.masterregion.protocol.acl": "*"
+        }
+      }
+    },
+    {
+      "ams-hbase-security-site": {
+        "properties": {
+          "ams.zookeeper.keytab": "",
+          "ams.zookeeper.principal": "",
+          "hadoop.security.authentication": "",
+          "hbase.coprocessor.master.classes": "",
+          "hbase.coprocessor.region.classes": "",
+          "hbase.master.kerberos.principal": "",
+          "hbase.master.keytab.file": "",
+          "hbase.myclient.keytab": "",
+          "hbase.myclient.principal": "",
+          "hbase.regionserver.kerberos.principal": "",
+          "hbase.regionserver.keytab.file": "",
+          "hbase.security.authentication": "",
+          "hbase.security.authorization": "",
+          "hbase.zookeeper.property.authProvider.1": "",
+          "hbase.zookeeper.property.jaasLoginRenew": "",
+          "hbase.zookeeper.property.kerberos.removeHostFromPrincipal": "",
+          "hbase.zookeeper.property.kerberos.removeRealmFromPrincipal": "",
+          "zookeeper.znode.parent": ""
+        }
+      }
+    },
+    {
+      "ams-hbase-site": {
+        "properties": {
+          "hbase.client.scanner.caching": "10000",
+          "hbase.client.scanner.timeout.period": "900000",
+          "hbase.cluster.distributed": "false",
+          "hbase.hregion.majorcompaction": "0",
+          "hbase.hregion.memstore.block.multiplier": "4",
+          "hbase.hregion.memstore.flush.size": "134217728",
+          "hbase.hstore.blockingStoreFiles": "200",
+          "hbase.hstore.flusher.count": "2",
+          "hbase.local.dir": "${hbase.tmp.dir}/local",
+          "hbase.master.info.bindAddress": "0.0.0.0",
+          "hbase.master.info.port": "61310",
+          "hbase.master.port": "61300",
+          "hbase.master.wait.on.regionservers.mintostart": "1",
+          "hbase.regionserver.global.memstore.lowerLimit": "0.3",
+          "hbase.regionserver.global.memstore.upperLimit": "0.35",
+          "hbase.regionserver.info.port": "61330",
+          "hbase.regionserver.port": "61320",
+          "hbase.regionserver.thread.compaction.large": "2",
+          "hbase.regionserver.thread.compaction.small": "3",
+          "hbase.replication": "false",
+          "hbase.rootdir": "file:///var/lib/ambari-metrics-collector/hbase",
+          "hbase.snapshot.enabled": "false",
+          "hbase.tmp.dir": "/var/lib/ambari-metrics-collector/hbase-tmp",
+          "hbase.zookeeper.leaderport": "61388",
+          "hbase.zookeeper.peerport": "61288",
+          "hbase.zookeeper.property.clientPort": "61181",
+          "hbase.zookeeper.property.dataDir": "${hbase.tmp.dir}/zookeeper",
+          "hbase.zookeeper.quorum": "{{zookeeper_quorum_hosts}}",
+          "hfile.block.cache.size": "0.3",
+          "phoenix.groupby.maxCacheSize": "307200000",
+          "phoenix.query.maxGlobalMemoryPercentage": "15",
+          "phoenix.query.spoolThresholdBytes": "12582912",
+          "phoenix.query.timeoutMs": "1200000",
+          "phoenix.sequence.saltBuckets": "2",
+          "phoenix.spool.directory": "${hbase.tmp.dir}/phoenix-spool",
+          "zookeeper.session.timeout": "120000",
+          "zookeeper.session.timeout.localHBaseCluster": "20000"
+        }
+      }
+    },
+    {
+      "ams-log4j": {
+        "properties": {
+          "content": "\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n\n# Define some default values that can be overridden by system properties\nams.log.dir=.\nams.log.file=ambari-metrics-collector.log\n\n# Root logger option\nlog4j.rootLogger=INFO,file\n\n# Direct log messages to a log file\nlog4j.appender.file=org.apache.log4j.RollingFileAppender\nlog4j.appender.file.File=${ams.log.dir}/${ams.log.file}\nlog4j.appender.file.MaxFileSize=80MB\nlog4j.appender.file.MaxBackupIndex=60\nlog4j.appender.file.layout=org.apache.log4j.PatternLayout\nlog4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p [%t] %c{1}:%L - %m%n"
+        }
+      }
+    },
+    {
+      "ams-site": {
+        "properties": {
+          "phoenix.query.maxGlobalMemoryPercentage": "25",
+          "phoenix.spool.directory": "/tmp",
+          "timeline.metrics.aggregator.checkpoint.dir": "/var/lib/ambari-metrics-collector/checkpoint",
+          "timeline.metrics.cluster.aggregator.hourly.checkpointCutOffMultiplier": "2",
+          "timeline.metrics.cluster.aggregator.hourly.disabled": "false",
+          "timeline.metrics.cluster.aggregator.hourly.interval": "3600",
+          "timeline.metrics.cluster.aggregator.hourly.ttl": "31536000",
+          "timeline.metrics.cluster.aggregator.minute.checkpointCutOffMultiplier": "2",
+          "timeline.metrics.cluster.aggregator.minute.disabled": "false",
+          "timeline.metrics.cluster.aggregator.minute.interval": "120",
+          "timeline.metrics.cluster.aggregator.minute.timeslice.interval": "15",
+          "timeline.metrics.cluster.aggregator.minute.ttl": "2592000",
+          "timeline.metrics.hbase.compression.scheme": "SNAPPY",
+          "timeline.metrics.hbase.data.block.encoding": "FAST_DIFF",
+          "timeline.metrics.host.aggregator.hourly.checkpointCutOffMultiplier": "2",
+          "timeline.metrics.host.aggregator.hourly.disabled": "false",
+          "timeline.metrics.host.aggregator.hourly.interval": "3600",
+          "timeline.metrics.host.aggregator.hourly.ttl": "2592000",
+          "timeline.metrics.host.aggregator.minute.checkpointCutOffMultiplier": "2",
+          "timeline.metrics.host.aggregator.minute.disabled": "false",
+          "timeline.metrics.host.aggregator.minute.interval": "120",
+          "timeline.metrics.host.aggregator.minute.ttl": "604800",
+          "timeline.metrics.host.aggregator.ttl": "86400",
+          "timeline.metrics.service.checkpointDelay": "60",
+          "timeline.metrics.service.default.result.limit": "5760",
+          "timeline.metrics.service.operation.mode": "embedded",
+          "timeline.metrics.service.resultset.fetchSize": "2000",
+          "timeline.metrics.service.rpc.address": "0.0.0.0:60200",
+          "timeline.metrics.service.webapp.address": "0.0.0.0:6188"
+        }
+      }
+    },
+    {
+      "capacity-scheduler": {
+        "properties": {
+          "yarn.scheduler.capacity.default.minimum-user-limit-percent": "100",
+          "yarn.scheduler.capacity.maximum-am-resource-percent": "0.2",
+          "yarn.scheduler.capacity.maximum-applications": "10000",
+          "yarn.scheduler.capacity.node-locality-delay": "40",
+          "yarn.scheduler.capacity.resource-calculator": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator",
+          "yarn.scheduler.capacity.root.accessible-node-labels": "*",
+          "yarn.scheduler.capacity.root.accessible-node-labels.default.capacity": "-1",
+          "yarn.scheduler.capacity.root.accessible-node-labels.default.maximum-capacity": "-1",
+          "yarn.scheduler.capacity.root.acl_administer_queue": "*",
+          "yarn.scheduler.capacity.root.capacity": "100",
+          "yarn.scheduler.capacity.root.default-node-label-expression": " ",
+          "yarn.scheduler.capacity.root.default.acl_administer_jobs": "*",
+          "yarn.scheduler.capacity.root.default.acl_submit_applications": "*",
+          "yarn.scheduler.capacity.root.default.capacity": "100",
+          "yarn.scheduler.capacity.root.default.maximum-capacity": "100",
+          "yarn.scheduler.capacity.root.default.state": "RUNNING",
+          "yarn.scheduler.capacity.root.default.user-limit-factor": "1",
+          "yarn.scheduler.capacity.root.queues": "default"
+        }
+      }
+    },
+    {
+      "cluster-env": {
+        "properties": {
+          "hadoop-streaming_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/mapreduce/",
+          "hadoop-streaming_tar_source": "/usr/hdp/current/hadoop-mapreduce-client/hadoop-streaming.jar",
+          "hive_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/hive/",
+          "hive_tar_source": "/usr/hdp/current/hive-client/hive.tar.gz",
+          "ignore_groupsusers_create": "false",
+          "kerberos_domain": "EXAMPLE.COM",
+          "mapreduce_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/mapreduce/",
+          "mapreduce_tar_source": "/usr/hdp/current/hadoop-client/mapreduce.tar.gz",
+          "pig_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/pig/",
+          "pig_tar_source": "/usr/hdp/current/pig-client/pig.tar.gz",
+          "security_enabled": "false",
+          "smokeuser": "ambari-qa",
+          "smokeuser_keytab": "/etc/security/keytabs/smokeuser.headless.keytab",
+          "sqoop_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/sqoop/",
+          "sqoop_tar_source": "/usr/hdp/current/sqoop-client/sqoop.tar.gz",
+          "tez_tar_destination_folder": "hdfs:///hdp/apps/{{ hdp_stack_version }}/tez/",
+          "tez_tar_source": "/usr/hdp/current/tez-client/lib/tez.tar.gz",
+          "user_group": "hadoop"
+        }
+      }
+    },
+    {
+      "core-site": {
+        "properties_attributes": {
+          "final": {
+            "fs.defaultFS": "true"
+          }
+        },
+        "properties": {
+          "fs.defaultFS": "hdfs://%HOSTGROUP::host_group_master_1%:8020",
+          "fs.trash.interval": "360",
+          "ha.failover-controller.active-standby-elector.zk.op.retries": "120",
+          "hadoop.http.authentication.simple.anonymous.allowed": "true",
+          "hadoop.proxyuser.falcon.groups": "users",
+          "hadoop.proxyuser.falcon.hosts": "*",
+          "hadoop.proxyuser.hcat.groups": "users",
+          "hadoop.proxyuser.hcat.hosts": "%HOSTGROUP::host_group_master_2%",
+          "hadoop.proxyuser.hive.groups": "users",
+          "hadoop.proxyuser.hive.hosts": "%HOSTGROUP::host_group_master_2%",
+          "hadoop.proxyuser.oozie.groups": "*",
+          "hadoop.proxyuser.oozie.hosts": "%HOSTGROUP::host_group_master_1%",
+          "hadoop.security.auth_to_local": "\n        DEFAULT",
+          "hadoop.security.authentication": "simple",
+          "hadoop.security.authorization": "false",
+          "io.compression.codecs": "org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.SnappyCodec",
+          "io.file.buffer.size": "131072",
+          "io.serializations": "org.apache.hadoop.io.serializer.WritableSerialization",
+          "ipc.client.connect.max.retries": "50",
+          "ipc.client.connection.maxidletime": "30000",
+          "ipc.client.idlethreshold": "8000",
+          "ipc.server.tcpnodelay": "true",
+          "mapreduce.jobtracker.webinterface.trusted": "false",
+          "proxyuser_group": "users"
+        }
+      }
+    },
+    {
+      "falcon-env": {
+        "properties": {
+          "content": "\n# The java implementation to use. If JAVA_HOME is not found we expect java and jar to be in path\nexport JAVA_HOME={{java_home}}\n\n# any additional java opts you want to set. This will apply to both client and server operations\n#export FALCON_OPTS=\n\n# any additional java opts that you want to set for client only\n#export FALCON_CLIENT_OPTS=\n\n# java heap size we want to set for the client. Default is 1024MB\n#export FALCON_CLIENT_HEAP=\n\n# any additional opts you want to set for prisim service.\n#export FALCON_PRISM_OPTS=\n\n# java heap size we want to set for the prisim service. Default is 1024MB\n#export FALCON_PRISM_HEAP=\n\n# any additional opts you want to set for falcon service.\nexport FALCON_SERVER_OPTS=\"-Dfalcon.embeddedmq={{falcon_embeddedmq_enabled}} -Dfalcon.emeddedmq.port={{falcon_emeddedmq_port}}\"\n\n# java heap size we want to set for the falcon server. Default is 1024MB\n#export FALCON_SERVER_HEAP=\n\n# What is is considered as falcon home dir. Default is the base location of the installed software\n#export FALCON_HOME_DIR=\n\n# Where log files are stored. Defatult is logs directory under the base install location\nexport FALCON_LOG_DIR={{falcon_log_dir}}\n\n# Where pid files are stored. Defatult is logs directory under the base install location\nexport FALCON_PID_DIR={{falcon_pid_dir}}\n\n# where the falcon active mq data is stored. Defatult is logs/data directory under the base install location\nexport FALCON_DATA_DIR={{falcon_embeddedmq_data}}\n\n# Where do you want to expand the war file. By Default it is in /server/webapp dir under the base install dir.\n#export FALCON_EXPANDED_WEBAPP_DIR=",
+          "falcon.embeddedmq": "true",
+          "falcon.embeddedmq.data": "/hadoop/falcon/embeddedmq/data",
+          "falcon.emeddedmq.port": "61616",
+          "falcon_local_dir": "/hadoop/falcon",
+          "falcon_log_dir": "/var/log/falcon",
+          "falcon_pid_dir": "/var/run/falcon",
+          "falcon_port": "15000",
+          "falcon_store_uri": "file:///hadoop/falcon/store",
+          "falcon_user": "falcon"
+        }
+      }
+    },
+    {
+      "falcon-runtime.properties": {
+        "properties": {
+          "*.domain": "${falcon.app.type}",
+          "*.log.cleanup.frequency.days.retention": "days(7)",
+          "*.log.cleanup.frequency.hours.retention": "minutes(1)",
+          "*.log.cleanup.frequency.minutes.retention": "hours(6)",
+          "*.log.cleanup.frequency.months.retention": "months(3)"
+        }
+      }
+    },
+    {
+      "falcon-startup.properties": {
+        "properties": {
+          "*.ConfigSyncService.impl": "org.apache.falcon.resource.ConfigSyncService",
+          "*.ProcessInstanceManager.impl": "org.apache.falcon.resource.InstanceManager",
+          "*.SchedulableEntityManager.impl": "org.apache.falcon.resource.SchedulableEntityManager",
+          "*.application.services": "org.apache.falcon.security.AuthenticationInitializationService,\\\n      org.apache.falcon.workflow.WorkflowJobEndNotificationService, \\\n      org.apache.falcon.service.ProcessSubscriberService,\\\n      org.apache.falcon.entity.store.ConfigurationStore,\\\n      org.apache.falcon.rerun.service.RetryService,\\\n      org.apache.falcon.rerun.service.LateRunService,\\\n      org.apache.falcon.service.LogCleanupService,\\\n      org.apache.falcon.metadata.MetadataMappingService",
+          "*.broker.impl.class": "org.apache.activemq.ActiveMQConnectionFactory",
+          "*.broker.ttlInMins": "4320",
+          "*.broker.url": "tcp://%HOSTGROUP::host_group_master_1%:61616",
+          "*.catalog.service.impl": "org.apache.falcon.catalog.HiveCatalogService",
+          "*.config.store.uri": "file:///hadoop/falcon/store",
+          "*.configstore.listeners": "org.apache.falcon.entity.v0.EntityGraph,\\\n      org.apache.falcon.entity.ColoClusterRelation,\\\n      org.apache.falcon.group.FeedGroupMap,\\\n      org.apache.falcon.service.SharedLibraryHostingService",
+          "*.dfs.namenode.kerberos.principal": "nn/_HOST@EXAMPLE.COM",
+          "*.domain": "${falcon.app.type}",
+          "*.entity.topic": "FALCON.ENTITY.TOPIC",
+          "*.falcon.authentication.type": "simple",
+          "*.falcon.cleanup.service.frequency": "days(1)",
+          "*.falcon.enableTLS": "false",
+          "*.falcon.graph.blueprints.graph": "com.thinkaurelius.titan.core.TitanFactory",
+          "*.falcon.graph.preserve.history": "false",
+          "*.falcon.graph.serialize.path": "/mnt/hadoop/falcon/data/lineage",
+          "*.falcon.graph.storage.backend": "berkeleyje",
+          "*.falcon.graph.storage.directory": "/mnt/hadoop/falcon/data/lineage/graphdb",
+          "*.falcon.http.authentication.blacklisted.users": "",
+          "*.falcon.http.authentication.cookie.domain": "EXAMPLE.COM",
+          "*.falcon.http.authentication.kerberos.keytab": "/etc/security/keytabs/spnego.service.keytab",
+          "*.falcon.http.authentication.kerberos.name.rules": "DEFAULT",
+          "*.falcon.http.authentication.signature.secret": "falcon",
+          "*.falcon.http.authentication.simple.anonymous.allowed": "true",
+          "*.falcon.http.authentication.token.validity": "36000",
+          "*.falcon.http.authentication.type": "simple",
+          "*.falcon.security.authorization.admin.groups": "falcon",
+          "*.falcon.security.authorization.admin.users": "falcon,ambari-qa",
+          "*.falcon.security.authorization.enabled": "false",
+          "*.falcon.security.authorization.provider": "org.apache.falcon.security.DefaultAuthorizationProvider",
+          "*.falcon.security.authorization.superusergroup": "falcon",
+          "*.falcon.service.authentication.kerberos.keytab": "/etc/security/keytabs/falcon.service.keytab",
+          "*.internal.queue.size": "1000",
+          "*.journal.impl": "org.apache.falcon.transaction.SharedFileSystemJournal",
+          "*.max.retry.failure.count": "1",
+          "*.oozie.feed.workflow.builder": "org.apache.falcon.workflow.OozieFeedWorkflowBuilder",
+          "*.oozie.process.workflow.builder": "org.apache.falcon.workflow.OozieProcessWorkflowBuilder",
+          "*.retry.recorder.path": "${falcon.log.dir}/retry",
+          "*.shared.libs": "activemq-core,ant,geronimo-j2ee-management,hadoop-distcp,jms,json-simple,oozie-client,spring-jms",
+          "*.system.lib.location": "${falcon.home}/server/webapp/${falcon.app.type}/WEB-INF/lib",
+          "*.workflow.engine.impl": "org.apache.falcon.workflow.engine.OozieWorkflowEngine",
+          "prism.application.services": "org.apache.falcon.entity.store.ConfigurationStore",
+          "prism.configstore.listeners": "org.apache.falcon.entity.v0.EntityGraph,\\\n      org.apache.falcon.entity.ColoClusterRelation,\\\n      org.apache.falcon.group.FeedGroupMap"
+        }
+      }
+    },
+    {
+      "flume-conf": {
+        "properties": {
+          "content": "\n# Flume agent config"
+        }
+      }
+    },
+    {
+      "flume-env": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one or more\n# contributor license agreements.  See the NOTICE file distributed with\n# this work for additional information regarding copyright ownership.\n# The ASF licenses this file to You under the Apache License, Version 2.0\n# (the \"License\"); you may not use this file except in compliance with\n# the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n# If this file is placed at FLUME_CONF_DIR/flume-env.sh, it will be sourced\n# during Flume startup.\n\n# Enviroment variables can be set here.\n\nexport JAVA_HOME={{java_home}}\n\n# Give Flume more memory and pre-allocate, enable remote monitoring via JMX\n# export JAVA_OPTS=\"-Xms100m -Xmx2000m -Dcom.sun.management.jmxremote\"\n\n# Note that the Flume conf directory is always included in the classpath.\n# Add flume sink to classpath\nif [ -e \"/usr/lib/flume/lib/ambari-metrics-flume-sink.jar\" ]; then\n  export FLUME_CLASSPATH=$FLUME_CLASSPATH:/usr/lib/flume/lib/ambari-metrics-flume-sink.jar\nfi\n\nexport HIVE_HOME={{flume_hive_home}}\nexport HCAT_HOME={{flume_hcat_home}}",
+          "flume_conf_dir": "/etc/flume/conf",
+          "flume_log_dir": "/var/log/flume",
+          "flume_user": "flume"
+        }
+      }
+    },
+    {
+      "gateway-log4j": {
+        "properties": {
+          "content": "\n\n      # Licensed to the Apache Software Foundation (ASF) under one\n      # or more contributor license agreements. See the NOTICE file\n      # distributed with this work for additional information\n      # regarding copyright ownership. The ASF licenses this file\n      # to you under the Apache License, Version 2.0 (the\n      # \"License\"); you may not use this file except in compliance\n      # with the License. You may obtain a copy of the License at\n      #\n      # http://www.apache.org/licenses/LICENSE-2.0\n      #\n      # Unless required by applicable law or agreed to in writing, software\n      # distributed under the License is distributed on an \"AS IS\" BASIS,\n      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n      # See the License for the specific language governing permissions and\n      # limitations under the License.\n\n      app.log.dir=${launcher.dir}/../logs\n      app.log.file=${launcher.name}.log\n      app.audit.file=${launcher.name}-audit.log\n\n      log4j.rootLogger=ERROR, drfa\n\n      log4j.logger.org.apache.hadoop.gateway=INFO\n      #log4j.logger.org.apache.hadoop.gateway=DEBUG\n\n      #log4j.logger.org.eclipse.jetty=DEBUG\n      #log4j.logger.org.apache.shiro=DEBUG\n      #log4j.logger.org.apache.http=DEBUG\n      #log4j.logger.org.apache.http.client=DEBUG\n      #log4j.logger.org.apache.http.headers=DEBUG\n      #log4j.logger.org.apache.http.wire=DEBUG\n\n      log4j.appender.stdout=org.apache.log4j.ConsoleAppender\n      log4j.appender.stdout.layout=org.apache.log4j.PatternLayout\n      log4j.appender.stdout.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\n\n      log4j.appender.drfa=org.apache.log4j.DailyRollingFileAppender\n      log4j.appender.drfa.File=${app.log.dir}/${app.log.file}\n      log4j.appender.drfa.DatePattern=.yyyy-MM-dd\n      log4j.appender.drfa.layout=org.apache.log4j.PatternLayout\n      log4j.appender.drfa.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n      log4j.logger.audit=INFO, auditfile\n      log4j.appender.auditfile=org.apache.log4j.DailyRollingFileAppender\n      log4j.appender.auditfile.File=${app.log.dir}/${app.audit.file}\n      log4j.appender.auditfile.Append = true\n      log4j.appender.auditfile.DatePattern = '.'yyyy-MM-dd\n      log4j.appender.auditfile.layout = org.apache.hadoop.gateway.audit.log4j.layout.AuditLayout"
+        }
+      }
+    },
+    {
+      "gateway-site": {
+        "properties": {
+          "gateway.gateway.conf.dir": "deployments",
+          "gateway.hadoop.kerberos.secured": "false",
+          "gateway.path": "gateway",
+          "gateway.port": "8443",
+          "java.security.auth.login.config": "/etc/knox/conf/krb5JAASLogin.conf",
+          "java.security.krb5.conf": "/etc/knox/conf/krb5.conf",
+          "sun.security.krb5.debug": "true"
+        }
+      }
+    },
+    {
+      "hadoop-env": {
+        "properties": {
+          "content": "\n# Set Hadoop-specific environment variables here.\n\n# The only required environment variable is JAVA_HOME.  All others are\n# optional.  When running a distributed configuration it is best to\n# set JAVA_HOME in this file, so that it is correctly defined on\n# remote nodes.\n\n# The java implementation to use.  Required.\nexport JAVA_HOME={{java_home}}\nexport HADOOP_HOME_WARN_SUPPRESS=1\n\n# Hadoop home directory\nexport HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\n# Hadoop Configuration Directory\n\n{# this is different for HDP1 #}\n# Path to jsvc required by secure HDP 2.0 datanode\nexport JSVC_HOME={{jsvc_path}}\n\n\n# The maximum amount of heap to use, in MB. Default is 1000.\nexport HADOOP_HEAPSIZE=\"{{hadoop_heapsize}}\"\n\nexport HADOOP_NAMENODE_INIT_HEAPSIZE=\"-Xms{{namenode_heapsize}}\"\n\n# Extra Java runtime options.  Empty by default.\nexport HADOOP_OPTS=\"-Djava.net.preferIPv4Stack=true ${HADOOP_OPTS}\"\n\n# Command specific options appended to HADOOP_OPTS when specified\nexport HADOOP_NAMENODE_OPTS=\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{namenode_opt_newsize}} -XX:MaxNewSize={{namenode_opt_maxnewsize}} -XX:PermSize={{namenode_opt_permsize}} -XX:MaxPermSize={{namenode_opt_maxpermsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xms{{namenode_heapsize}} -Xmx{{namenode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT ${HADOOP_NAMENODE_OPTS}\"\nHADOOP_JOBTRACKER_OPTS=\"-server -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:ErrorFile={{hdfs_log_dir_prefix}}/$USER/hs_err_pid%p.log -XX:NewSize={{jtnode_opt_newsize}} -XX:MaxNewSize={{jtnode_opt_maxnewsize}} -Xloggc:{{hdfs_log_dir_prefix}}/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xmx{{jtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dmapred.audit.logger=INFO,MRAUDIT -Dhadoop.mapreduce.jobsummary.logger=INFO,JSA ${HADOOP_JOBTRACKER_OPTS}\"\n\nHADOOP_TASKTRACKER_OPTS=\"-server -Xmx{{ttnode_heapsize}} -Dhadoop.security.logger=ERROR,console -Dmapred.audit.logger=ERROR,console ${HADOOP_TASKTRACKER_OPTS}\"\nexport HADOOP_DATANODE_OPTS=\"-server -XX:ParallelGCThreads=4 -XX:+UseConcMarkSweepGC -XX:ErrorFile=/var/log/hadoop/$USER/hs_err_pid%p.log -XX:NewSize=200m -XX:MaxNewSize=200m -XX:PermSize=128m -XX:MaxPermSize=256m -Xloggc:/var/log/hadoop/$USER/gc.log-`date +'%Y%m%d%H%M'` -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xms{{dtnode_heapsize}} -Xmx{{dtnode_heapsize}} -Dhadoop.security.logger=INFO,DRFAS -Dhdfs.audit.logger=INFO,DRFAAUDIT ${HADOOP_DATANODE_OPTS}\"\nHADOOP_BALANCER_OPTS=\"-server -Xmx{{hadoop_heapsize}}m ${HADOOP_BALANCER_OPTS}\"\n\nexport HADOOP_SECONDARYNAMENODE_OPTS=$HADOOP_NAMENODE_OPTS\n\n# The following applies to multiple commands (fs, dfs, fsck, distcp etc)\nexport HADOOP_CLIENT_OPTS=\"-Xmx${HADOOP_HEAPSIZE}m -XX:MaxPermSize=512m $HADOOP_CLIENT_OPTS\"\n\n# On secure datanodes, user to run the datanode as after dropping privileges\nexport HADOOP_SECURE_DN_USER=${HADOOP_SECURE_DN_USER:-{{hadoop_secure_dn_user}}}\n\n# Extra ssh options.  Empty by default.\nexport HADOOP_SSH_OPTS=\"-o ConnectTimeout=5 -o SendEnv=HADOOP_CONF_DIR\"\n\n# Where log files are stored.  $HADOOP_HOME/logs by default.\nexport HADOOP_LOG_DIR={{hdfs_log_dir_prefix}}/$USER\n\n# History server logs\nexport HADOOP_MAPRED_LOG_DIR={{mapred_log_dir_prefix}}/$USER\n\n# Where log files are stored in the secure data environment.\nexport HADOOP_SECURE_DN_LOG_DIR={{hdfs_log_dir_prefix}}/$HADOOP_SECURE_DN_USER\n\n# File naming remote slave hosts.  $HADOOP_HOME/conf/slaves by default.\n# export HADOOP_SLAVES=${HADOOP_HOME}/conf/slaves\n\n# host:path where hadoop code should be rsync'd from.  Unset by default.\n# export HADOOP_MASTER=master:/home/$USER/src/hadoop\n\n# Seconds to sleep between slave commands.  Unset by default.  This\n# can be useful in large clusters, where, e.g., slave rsyncs can\n# otherwise arrive faster than the master can service them.\n# export HADOOP_SLAVE_SLEEP=0.1\n\n# The directory where pid files are stored. /tmp by default.\nexport HADOOP_PID_DIR={{hadoop_pid_dir_prefix}}/$USER\nexport HADOOP_SECURE_DN_PID_DIR={{hadoop_pid_dir_prefix}}/$HADOOP_SECURE_DN_USER\n\n# History server pid\nexport HADOOP_MAPRED_PID_DIR={{mapred_pid_dir_prefix}}/$USER\n\nYARN_RESOURCEMANAGER_OPTS=\"-Dyarn.server.resourcemanager.appsummary.logger=INFO,RMSUMMARY\"\n\n# A string representing this instance of hadoop. $USER by default.\nexport HADOOP_IDENT_STRING=$USER\n\n# The scheduling priority for daemon processes.  See 'man nice'.\n\n# export HADOOP_NICENESS=10\n\n# Use libraries from standard classpath\nJAVA_JDBC_LIBS=\"\"\n#Add libraries required by mysql connector\nfor jarFile in `ls /usr/share/java/*mysql* 2>/dev/null`\ndo\n  JAVA_JDBC_LIBS=${JAVA_JDBC_LIBS}:$jarFile\ndone\n# Add libraries required by oracle connector\nfor jarFile in `ls /usr/share/java/*ojdbc* 2>/dev/null`\ndo\n  JAVA_JDBC_LIBS=${JAVA_JDBC_LIBS}:$jarFile\ndone\n# Add libraries required by nodemanager\nMAPREDUCE_LIBS={{mapreduce_libs_path}}\nexport HADOOP_CLASSPATH=${HADOOP_CLASSPATH}${JAVA_JDBC_LIBS}:${MAPREDUCE_LIBS}\n\n# added to the HADOOP_CLASSPATH\nif [ -d \"/usr/hdp/current/tez-client\" ]; then\n  if [ -d \"/etc/tez/conf/\" ]; then\n    # When using versioned RPMs, the tez-client will be a symlink to the current folder of tez in HDP.\n    export HADOOP_CLASSPATH=${HADOOP_CLASSPATH}:/usr/hdp/current/tez-client/*:/usr/hdp/current/tez-client/lib/*:/etc/tez/conf/\n  fi\nfi\n\n\n# Setting path to hdfs command line\nexport HADOOP_LIBEXEC_DIR={{hadoop_libexec_dir}}\n\n# Mostly required for hadoop 2.0\nexport JAVA_LIBRARY_PATH=${JAVA_LIBRARY_PATH}\n\nexport HADOOP_OPTS=\"-Dhdp.version=$HDP_VERSION $HADOOP_OPTS\"",
+          "dfs.datanode.data.dir.mount.file": "/etc/hadoop/conf/dfs_data_dir_mount.hist",
+          "dtnode_heapsize": "1024m",
+          "hadoop_heapsize": "1024",
+          "hadoop_pid_dir_prefix": "/var/run/hadoop",
+          "hadoop_root_logger": "INFO,RFA",
+          "hdfs_log_dir_prefix": "/var/log/hadoop",
+          "hdfs_user": "hdfs",
+          "namenode_heapsize": "1024m",
+          "namenode_opt_maxnewsize": "256m",
+          "namenode_opt_maxpermsize": "256m",
+          "namenode_opt_newsize": "256m",
+          "namenode_opt_permsize": "128m",
+          "proxyuser_group": "users"
+        }
+      }
+    },
+    {
+      "hadoop-policy": {
+        "properties": {
+          "security.admin.operations.protocol.acl": "hadoop",
+          "security.client.datanode.protocol.acl": "*",
+          "security.client.protocol.acl": "*",
+          "security.datanode.protocol.acl": "*",
+          "security.inter.datanode.protocol.acl": "*",
+          "security.inter.tracker.protocol.acl": "*",
+          "security.job.client.protocol.acl": "*",
+          "security.job.task.protocol.acl": "*",
+          "security.namenode.protocol.acl": "*",
+          "security.refresh.policy.protocol.acl": "hadoop",
+          "security.refresh.usertogroups.mappings.protocol.acl": "hadoop"
+        }
+      }
+    },
+    {
+      "hbase-env": {
+        "properties": {
+          "content": "\n# Set environment variables here.\n\n# The java implementation to use. Java 1.6 required.\nexport JAVA_HOME={{java64_home}}\n\n# HBase Configuration directory\nexport HBASE_CONF_DIR=${HBASE_CONF_DIR:-{{hbase_conf_dir}}}\n\n# Extra Java CLASSPATH elements. Optional.\nexport HBASE_CLASSPATH=${HBASE_CLASSPATH}\n\n\n# The maximum amount of heap to use, in MB. Default is 1000.\n# export HBASE_HEAPSIZE=1000\n\n# Extra Java runtime options.\n# Below are what we set by default. May only work with SUN JVM.\n# For more on why as well as other possible settings,\n# see http://wiki.apache.org/hadoop/PerformanceTuning\nexport SERVER_GC_OPTS=\"-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:{{log_dir}}/gc.log-`date +'%Y%m%d%H%M'`\"\n# Uncomment below to enable java garbage collection logging.\n# export HBASE_OPTS=\"$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:$HBASE_HOME/logs/gc-hbase.log\"\n\n# Uncomment and adjust to enable JMX exporting\n# See jmxremote.password and jmxremote.access in $JRE_HOME/lib/management to configure remote password access.\n# More details at: http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html\n#\n# export HBASE_JMX_BASE=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\"\n# If you want to configure BucketCache, specify '-XX: MaxDirectMemorySize=' with proper direct memory size\n# export HBASE_THRIFT_OPTS=\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10103\"\n# export HBASE_ZOOKEEPER_OPTS=\"$HBASE_JMX_BASE -Dcom.sun.management.jmxremote.port=10104\"\n\n# File naming hosts on which HRegionServers will run. $HBASE_HOME/conf/regionservers by default.\nexport HBASE_REGIONSERVERS=${HBASE_CONF_DIR}/regionservers\n\n# Extra ssh options. Empty by default.\n# export HBASE_SSH_OPTS=\"-o ConnectTimeout=1 -o SendEnv=HBASE_CONF_DIR\"\n\n# Where log files are stored. $HBASE_HOME/logs by default.\nexport HBASE_LOG_DIR={{log_dir}}\n\n# A string representing this instance of hbase. $USER by default.\n# export HBASE_IDENT_STRING=$USER\n\n# The scheduling priority for daemon processes. See 'man nice'.\n# export HBASE_NICENESS=10\n\n# The directory where pid files are stored. /tmp by default.\nexport HBASE_PID_DIR={{pid_dir}}\n\n# Seconds to sleep between slave commands. Unset by default. This\n# can be useful in large clusters, where, e.g., slave rsyncs can\n# otherwise arrive faster than the master can service them.\n# export HBASE_SLAVE_SLEEP=0.1\n\n# Tell HBase whether it should manage it's own instance of Zookeeper or not.\nexport HBASE_MANAGES_ZK=false\n\n{% if security_enabled %}\nexport HBASE_OPTS=\"$HBASE_OPTS -XX:+UseConcMarkSweepGC -XX:ErrorFile={{log_dir}}/hs_err_pid%p.log -Djava.security.auth.login.config={{client_jaas_config_file}}\"\nexport HBASE_MASTER_OPTS=\"$HBASE_MASTER_OPTS -Xmx{{master_heapsize}} -Djava.security.auth.login.config={{master_jaas_config_file}}\"\nexport HBASE_REGIONSERVER_OPTS=\"$HBASE_REGIONSERVER_OPTS -Xmn{{regionserver_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70  -Xms{{regionserver_heapsize}} -Xmx{{regionserver_heapsize}} -Djava.security.auth.login.config={{regionserver_jaas_config_file}}\"\n{% else %}\nexport HBASE_OPTS=\"$HBASE_OPTS -XX:+UseConcMarkSweepGC -XX:ErrorFile={{log_dir}}/hs_err_pid%p.log\"\nexport HBASE_MASTER_OPTS=\"$HBASE_MASTER_OPTS -Xmx{{master_heapsize}}\"\nexport HBASE_REGIONSERVER_OPTS=\"$HBASE_REGIONSERVER_OPTS -Xmn{{regionserver_xmn_size}} -XX:CMSInitiatingOccupancyFraction=70  -Xms{{regionserver_heapsize}} -Xmx{{regionserver_heapsize}}\"\n{% endif %}",
+          "hbase_log_dir": "/var/log/hbase",
+          "hbase_master_heapsize": "1024m",
+          "hbase_pid_dir": "/var/run/hbase",
+          "hbase_regionserver_heapsize": "1024m",
+          "hbase_regionserver_xmn_max": "512",
+          "hbase_regionserver_xmn_ratio": "0.2",
+          "hbase_user": "hbase"
+        }
+      }
+    },
+    {
+      "hbase-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n\n# Define some default values that can be overridden by system properties\nhbase.root.logger=INFO,console\nhbase.security.logger=INFO,console\nhbase.log.dir=.\nhbase.log.file=hbase.log\n\n# Define the root logger to the system property \"hbase.root.logger\".\nlog4j.rootLogger=${hbase.root.logger}\n\n# Logging Threshold\nlog4j.threshold=ALL\n\n#\n# Daily Rolling File Appender\n#\nlog4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFA.File=${hbase.log.dir}/${hbase.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern=.yyyy-MM-dd\n\n# 30-day backup\n#log4j.appender.DRFA.MaxBackupIndex=30\nlog4j.appender.DRFA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\nlog4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n# Rolling File Appender properties\nhbase.log.maxfilesize=256MB\nhbase.log.maxbackupindex=20\n\n# Rolling File Appender\nlog4j.appender.RFA=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFA.File=${hbase.log.dir}/${hbase.log.file}\n\nlog4j.appender.RFA.MaxFileSize=${hbase.log.maxfilesize}\nlog4j.appender.RFA.MaxBackupIndex=${hbase.log.maxbackupindex}\n\nlog4j.appender.RFA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n#\n# Security audit appender\n#\nhbase.security.log.file=SecurityAuth.audit\nhbase.security.log.maxfilesize=256MB\nhbase.security.log.maxbackupindex=20\nlog4j.appender.RFAS=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFAS.File=${hbase.log.dir}/${hbase.security.log.file}\nlog4j.appender.RFAS.MaxFileSize=${hbase.security.log.maxfilesize}\nlog4j.appender.RFAS.MaxBackupIndex=${hbase.security.log.maxbackupindex}\nlog4j.appender.RFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.category.SecurityLogger=${hbase.security.logger}\nlog4j.additivity.SecurityLogger=false\n#log4j.logger.SecurityLogger.org.apache.hadoop.hbase.security.access.AccessController=TRACE\n\n#\n# Null Appender\n#\nlog4j.appender.NullAppender=org.apache.log4j.varia.NullAppender\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2}: %m%n\n\n# Custom Logging levels\n\nlog4j.logger.org.apache.zookeeper=INFO\n#log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG\nlog4j.logger.org.apache.hadoop.hbase=DEBUG\n# Make these two classes INFO-level. Make them DEBUG to see more zk debug.\nlog4j.logger.org.apache.hadoop.hbase.zookeeper.ZKUtil=INFO\nlog4j.logger.org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher=INFO\n#log4j.logger.org.apache.hadoop.dfs=DEBUG\n# Set this class to log INFO only otherwise its OTT\n# Enable this to get detailed connection error/retry logging.\n# log4j.logger.org.apache.hadoop.hbase.client.HConnectionManager$HConnectionImplementation=TRACE\n\n\n# Uncomment this line to enable tracing on _every_ RPC call (this can be a lot of output)\n#log4j.logger.org.apache.hadoop.ipc.HBaseServer.trace=DEBUG\n\n# Uncomment the below if you want to remove logging of client region caching'\n# and scan of .META. messages\n# log4j.logger.org.apache.hadoop.hbase.client.HConnectionManager$HConnectionImplementation=INFO\n# log4j.logger.org.apache.hadoop.hbase.client.MetaScanner=INFO"
+        }
+      }
+    },
+    {
+      "hbase-policy": {
+        "properties": {
+          "security.admin.protocol.acl": "*",
+          "security.client.protocol.acl": "*",
+          "security.masterregion.protocol.acl": "*"
+        }
+      }
+    },
+    {
+      "hbase-site": {
+        "properties": {
+          "dfs.domain.socket.path": "/var/lib/hadoop-hdfs/dn_socket",
+          "hbase.client.keyvalue.maxsize": "10485760",
+          "hbase.client.scanner.caching": "100",
+          "hbase.cluster.distributed": "true",
+          "hbase.coprocessor.master.classes": "",
+          "hbase.coprocessor.region.classes": "",
+          "hbase.defaults.for.version.skip": "true",
+          "hbase.hregion.majorcompaction": "604800000",
+          "hbase.hregion.majorcompaction.jitter": "0.50",
+          "hbase.hregion.max.filesize": "10737418240",
+          "hbase.hregion.memstore.block.multiplier": "4",
+          "hbase.hregion.memstore.flush.size": "134217728",
+          "hbase.hregion.memstore.mslab.enabled": "true",
+          "hbase.hstore.blockingStoreFiles": "10",
+          "hbase.hstore.compactionThreshold": "3",
+          "hbase.local.dir": "${hbase.tmp.dir}/local",
+          "hbase.master.info.bindAddress": "0.0.0.0",
+          "hbase.master.info.port": "60010",
+          "hbase.master.port": "60000",
+          "hbase.regionserver.global.memstore.lowerLimit": "0.38",
+          "hbase.regionserver.global.memstore.upperLimit": "0.4",
+          "hbase.regionserver.handler.count": "60",
+          "hbase.regionserver.info.port": "60030",
+          "hbase.rootdir": "hdfs://%HOSTGROUP::host_group_master_1%:8020/apps/hbase/data",
+          "hbase.rpc.protection": "authentication",
+          "hbase.security.authentication": "simple",
+          "hbase.security.authorization": "false",
+          "hbase.superuser": "hbase",
+          "hbase.tmp.dir": "/mnt/hadoop/hbase",
+          "hbase.zookeeper.property.clientPort": "2181",
+          "hbase.zookeeper.quorum": "%HOSTGROUP::host_group_master_1%,%HOSTGROUP::host_group_master_3%,%HOSTGROUP::host_group_master_2%",
+          "hbase.zookeeper.useMulti": "true",
+          "hfile.block.cache.size": "0.40",
+          "zookeeper.session.timeout": "30000",
+          "zookeeper.znode.parent": "/hbase-unsecure"
+        }
+      }
+    },
+    {
+      "hcat-env": {
+        "properties": {
+          "content": "\n      # Licensed to the Apache Software Foundation (ASF) under one\n      # or more contributor license agreements. See the NOTICE file\n      # distributed with this work for additional information\n      # regarding copyright ownership. The ASF licenses this file\n      # to you under the Apache License, Version 2.0 (the\n      # \"License\"); you may not use this file except in compliance\n      # with the License. You may obtain a copy of the License at\n      #\n      # http://www.apache.org/licenses/LICENSE-2.0\n      #\n      # Unless required by applicable law or agreed to in writing, software\n      # distributed under the License is distributed on an \"AS IS\" BASIS,\n      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n      # See the License for the specific language governing permissions and\n      # limitations under the License.\n\n      JAVA_HOME={{java64_home}}\n      HCAT_PID_DIR={{hcat_pid_dir}}/\n      HCAT_LOG_DIR={{hcat_log_dir}}/\n      HCAT_CONF_DIR={{hcat_conf_dir}}\n      HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n      #DBROOT is the path where the connector jars are downloaded\n      DBROOT={{hcat_dbroot}}\n      USER={{hcat_user}}\n      METASTORE_PORT={{hive_metastore_port}}"
+        }
+      }
+    },
+    {
+      "hdfs-log4j": {
+        "properties": {
+          "content": "\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#  http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n\n\n# Define some default values that can be overridden by system properties\n# To change daemon root logger use hadoop_root_logger in hadoop-env\nhadoop.root.logger=INFO,console\nhadoop.log.dir=.\nhadoop.log.file=hadoop.log\n\n\n# Define the root logger to the system property \"hadoop.root.logger\".\nlog4j.rootLogger=${hadoop.root.logger}, EventCounter\n\n# Logging Threshold\nlog4j.threshhold=ALL\n\n#\n# Daily Rolling File Appender\n#\n\nlog4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFA.File=${hadoop.log.dir}/${hadoop.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern=.yyyy-MM-dd\n\n# 30-day backup\n#log4j.appender.DRFA.MaxBackupIndex=30\nlog4j.appender.DRFA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\nlog4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n# Debugging Pattern format\n#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\n\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\n\n#\n# TaskLog Appender\n#\n\n#Default values\nhadoop.tasklog.taskid=null\nhadoop.tasklog.iscleanup=false\nhadoop.tasklog.noKeepSplits=4\nhadoop.tasklog.totalLogFileSize=100\nhadoop.tasklog.purgeLogSplits=true\nhadoop.tasklog.logsRetainHours=12\n\nlog4j.appender.TLA=org.apache.hadoop.mapred.TaskLogAppender\nlog4j.appender.TLA.taskId=${hadoop.tasklog.taskid}\nlog4j.appender.TLA.isCleanup=${hadoop.tasklog.iscleanup}\nlog4j.appender.TLA.totalLogFileSize=${hadoop.tasklog.totalLogFileSize}\n\nlog4j.appender.TLA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.TLA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n\n#\n#Security audit appender\n#\nhadoop.security.logger=INFO,console\nhadoop.security.log.maxfilesize=256MB\nhadoop.security.log.maxbackupindex=20\nlog4j.category.SecurityLogger=${hadoop.security.logger}\nhadoop.security.log.file=SecurityAuth.audit\nlog4j.appender.DRFAS=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}\nlog4j.appender.DRFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.DRFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.appender.DRFAS.DatePattern=.yyyy-MM-dd\n\nlog4j.appender.RFAS=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}\nlog4j.appender.RFAS.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\nlog4j.appender.RFAS.MaxFileSize=${hadoop.security.log.maxfilesize}\nlog4j.appender.RFAS.MaxBackupIndex=${hadoop.security.log.maxbackupindex}\n\n#\n# hdfs audit logging\n#\nhdfs.audit.logger=INFO,console\nlog4j.logger.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=${hdfs.audit.logger}\nlog4j.additivity.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=false\nlog4j.appender.DRFAAUDIT=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.DRFAAUDIT.File=${hadoop.log.dir}/hdfs-audit.log\nlog4j.appender.DRFAAUDIT.layout=org.apache.log4j.PatternLayout\nlog4j.appender.DRFAAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n\nlog4j.appender.DRFAAUDIT.DatePattern=.yyyy-MM-dd\n\n#\n# mapred audit logging\n#\nmapred.audit.logger=INFO,console\nlog4j.logger.org.apache.hadoop.mapred.AuditLogger=${mapred.audit.logger}\nlog4j.additivity.org.apache.hadoop.mapred.AuditLogger=false\nlog4j.appender.MRAUDIT=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.MRAUDIT.File=${hadoop.log.dir}/mapred-audit.log\nlog4j.appender.MRAUDIT.layout=org.apache.log4j.PatternLayout\nlog4j.appender.MRAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n\nlog4j.appender.MRAUDIT.DatePattern=.yyyy-MM-dd\n\n#\n# Rolling File Appender\n#\n\nlog4j.appender.RFA=org.apache.log4j.RollingFileAppender\nlog4j.appender.RFA.File=${hadoop.log.dir}/${hadoop.log.file}\n\n# Logfile size and and 30-day backups\nlog4j.appender.RFA.MaxFileSize=256MB\nlog4j.appender.RFA.MaxBackupIndex=10\n\nlog4j.appender.RFA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} - %m%n\nlog4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\n# Custom Logging levels\n\nhadoop.metrics.log.level=INFO\n#log4j.logger.org.apache.hadoop.mapred.JobTracker=DEBUG\n#log4j.logger.org.apache.hadoop.mapred.TaskTracker=DEBUG\n#log4j.logger.org.apache.hadoop.fs.FSNamesystem=DEBUG\nlog4j.logger.org.apache.hadoop.metrics2=${hadoop.metrics.log.level}\n\n# Jets3t library\nlog4j.logger.org.jets3t.service.impl.rest.httpclient.RestS3Service=ERROR\n\n#\n# Null Appender\n# Trap security logger on the hadoop client side\n#\nlog4j.appender.NullAppender=org.apache.log4j.varia.NullAppender\n\n#\n# Event Counter Appender\n# Sends counts of logging messages at different severity levels to Hadoop Metrics.\n#\nlog4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter\n\n# Removes \"deprecated\" messages\nlog4j.logger.org.apache.hadoop.conf.Configuration.deprecation=WARN\n\n#\n# HDFS block state change log from block manager\n#\n# Uncomment the following to suppress normal block state change\n# messages from BlockManager in NameNode.\n#log4j.logger.BlockStateChange=WARN"
+        }
+      }
+    },
+    {
+      "hdfs-site": {
+        "properties_attributes": {
+          "final": {
+            "dfs.support.append": "true",
+            "dfs.namenode.http-address": "true"
+          }
+        },
+        "properties": {
+          "dfs.block.access.token.enable": "true",
+          "dfs.blockreport.initialDelay": "120",
+          "dfs.blocksize": "134217728",
+          "dfs.client.read.shortcircuit": "true",
+          "dfs.client.read.shortcircuit.streams.cache.size": "4096",
+          "dfs.cluster.administrators": " hdfs",
+          "dfs.datanode.address": "0.0.0.0:50010",
+          "dfs.datanode.balance.bandwidthPerSec": "6250000",
+          "dfs.datanode.data.dir": "/mnt/hadoop/hdfs/data",
+          "dfs.datanode.data.dir.perm": "750",
+          "dfs.datanode.du.reserved": "1073741824",
+          "dfs.datanode.failed.volumes.tolerated": "0",
+          "dfs.datanode.http.address": "0.0.0.0:50075",
+          "dfs.datanode.https.address": "0.0.0.0:50475",
+          "dfs.datanode.ipc.address": "0.0.0.0:8010",
+          "dfs.datanode.max.transfer.threads": "16384",
+          "dfs.domain.socket.path": "/var/lib/hadoop-hdfs/dn_socket",
+          "dfs.heartbeat.interval": "3",
+          "dfs.hosts.exclude": "/etc/hadoop/conf/dfs.exclude",
+          "dfs.http.policy": "HTTP_ONLY",
+          "dfs.https.port": "50470",
+          "dfs.journalnode.edits.dir": "/hadoop/hdfs/journalnode",
+          "dfs.journalnode.http-address": "0.0.0.0:8480",
+          "dfs.journalnode.https-address": "0.0.0.0:8481",
+          "dfs.namenode.accesstime.precision": "0",
+          "dfs.namenode.avoid.read.stale.datanode": "true",
+          "dfs.namenode.avoid.write.stale.datanode": "true",
+          "dfs.namenode.checkpoint.dir": "/mnt/hadoop/hdfs/namesecondary",
+          "dfs.namenode.checkpoint.edits.dir": "${dfs.namenode.checkpoint.dir}",
+          "dfs.namenode.checkpoint.period": "21600",
+          "dfs.namenode.checkpoint.txns": "1000000",
+          "dfs.namenode.handler.count": "100",
+          "dfs.namenode.http-address": "%HOSTGROUP::host_group_master_1%:50070",
+          "dfs.namenode.https-address": "%HOSTGROUP::host_group_master_1%:50470",
+          "dfs.namenode.name.dir": "/mnt/hadoop/hdfs/namenode",
+          "dfs.namenode.name.dir.restore": "true",
+          "dfs.namenode.safemode.threshold-pct": "1.0f",
+          "dfs.namenode.secondary.http-address": "%HOSTGROUP::host_group_master_3%:50090",
+          "dfs.namenode.stale.datanode.interval": "30000",
+          "dfs.namenode.startup.delay.block.deletion.sec": "3600",
+          "dfs.namenode.write.stale.datanode.ratio": "1.0f",
+          "dfs.permissions.enabled": "true",
+          "dfs.permissions.superusergroup": "hdfs",
+          "dfs.replication": "3",
+          "dfs.replication.max": "50",
+          "dfs.support.append": "true",
+          "dfs.webhdfs.enabled": "true",
+          "fs.permissions.umask-mode": "022"
+        }
+      }
+    },
+    {
+      "hive-env": {
+        "properties": {
+          "content": "\n if [ \"$SERVICE\" = \"cli\" ]; then\n   if [ -z \"$DEBUG\" ]; then\n     export HADOOP_OPTS=\"$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:+UseParNewGC -XX:-UseGCOverheadLimit\"\n   else\n     export HADOOP_OPTS=\"$HADOOP_OPTS -XX:NewRatio=12 -Xms10m -XX:MaxHeapFreeRatio=40 -XX:MinHeapFreeRatio=15 -XX:-UseGCOverheadLimit\"\n   fi\n fi\n\n# The heap size of the jvm stared by hive shell script can be controlled via:\n\n# Larger heap size may be required when running queries over large number of files or partitions.\n# By default hive shell scripts use a heap size of 256 (MB).  Larger heap size would also be\n# appropriate for hive server (hwi etc).\n\n\n# Set HADOOP_HOME to point to a specific hadoop install directory\nHADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\n# Hive Configuration Directory can be controlled by:\nexport HIVE_CONF_DIR={{hive_config_dir}}\n\n# Folder containing extra libraries required for hive compilation/execution can be controlled by:\nif [ \"${HIVE_AUX_JARS_PATH}\" != \"\" ]; then\n  if [ -f \"${HIVE_AUX_JARS_PATH}\" ]; then    \n    export HIVE_AUX_JARS_PATH=${HIVE_AUX_JARS_PATH}\n  elif [ -d \"/usr/hdp/current/hive-webhcat/share/hcatalog\" ]; then\n    export HIVE_AUX_JARS_PATH=/usr/hdp/current/hive-webhcat/share/hcatalog/hive-hcatalog-core.jar\n  fi\nelif [ -d \"/usr/hdp/current/hive-webhcat/share/hcatalog\" ]; then\n  export HIVE_AUX_JARS_PATH=/usr/hdp/current/hive-webhcat/share/hcatalog/hive-hcatalog-core.jar\nfi      \n\nexport METASTORE_PORT={{hive_metastore_port}}",
+          "hcat_log_dir": "/var/log/webhcat",
+          "hcat_pid_dir": "/var/run/webhcat",
+          "hcat_user": "hcat",
+          "hive_ambari_database": "MySQL",
+          "hive_ambari_host": "%HOSTGROUP::host_group_master_2%",
+          "hive_database": "New MySQL Database",
+          "hive_database_name": "hive",
+          "hive_database_type": "mysql",
+          "hive_existing_mssql_server_2_host": "",
+          "hive_existing_mssql_server_host": "",
+          "hive_existing_mysql_host": "",
+          "hive_existing_oracle_host": "",
+          "hive_existing_postgresql_host": "",
+          "hive_hostname": "%HOSTGROUP::host_group_master_2%",
+          "hive_log_dir": "/var/log/hive",
+          "hive_metastore_port": "9083",
+          "hive_pid_dir": "/var/run/hive",
+          "hive_user": "hive",
+          "webhcat_user": "hcat"
+        }
+      }
+    },
+    {
+      "hive-exec-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n# Define some default values that can be overridden by system properties\n\nhive.log.threshold=ALL\nhive.root.logger=INFO,FA\nhive.log.dir=${java.io.tmpdir}/${user.name}\nhive.query.id=hadoop\nhive.log.file=${hive.query.id}.log\n\n# Define the root logger to the system property \"hadoop.root.logger\".\nlog4j.rootLogger=${hive.root.logger}, EventCounter\n\n# Logging Threshold\nlog4j.threshhold=${hive.log.threshold}\n\n#\n# File Appender\n#\n\nlog4j.appender.FA=org.apache.log4j.FileAppender\nlog4j.appender.FA.File=${hive.log.dir}/${hive.log.file}\nlog4j.appender.FA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\n#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n# Debugging Pattern format\nlog4j.appender.FA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\n\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\n\n#custom logging levels\n#log4j.logger.xxx=DEBUG\n\n#\n# Event Counter Appender\n# Sends counts of logging messages at different severity levels to Hadoop Metrics.\n#\nlog4j.appender.EventCounter=org.apache.hadoop.hive.shims.HiveEventCounter\n\n\nlog4j.category.DataNucleus=ERROR,FA\nlog4j.category.Datastore=ERROR,FA\nlog4j.category.Datastore.Schema=ERROR,FA\nlog4j.category.JPOX.Datastore=ERROR,FA\nlog4j.category.JPOX.Plugin=ERROR,FA\nlog4j.category.JPOX.MetaData=ERROR,FA\nlog4j.category.JPOX.Query=ERROR,FA\nlog4j.category.JPOX.General=ERROR,FA\nlog4j.category.JPOX.Enhancer=ERROR,FA\n\n\n# Silence useless ZK logs\nlog4j.logger.org.apache.zookeeper.server.NIOServerCnxn=WARN,FA\nlog4j.logger.org.apache.zookeeper.ClientCnxnSocketNIO=WARN,FA"
+        }
+      }
+    },
+    {
+      "hive-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n# Define some default values that can be overridden by system properties\nhive.log.threshold=ALL\nhive.root.logger=INFO,DRFA\nhive.log.dir=${java.io.tmpdir}/${user.name}\nhive.log.file=hive.log\n\n# Define the root logger to the system property \"hadoop.root.logger\".\nlog4j.rootLogger=${hive.root.logger}, EventCounter\n\n# Logging Threshold\nlog4j.threshold=${hive.log.threshold}\n\n#\n# Daily Rolling File Appender\n#\n# Use the PidDailyerRollingFileAppend class instead if you want to use separate log files\n# for different CLI session.\n#\n# log4j.appender.DRFA=org.apache.hadoop.hive.ql.log.PidDailyRollingFileAppender\n\nlog4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender\n\nlog4j.appender.DRFA.File=${hive.log.dir}/${hive.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern=.yyyy-MM-dd\n\n# 30-day backup\n#log4j.appender.DRFA.MaxBackupIndex=30\nlog4j.appender.DRFA.layout=org.apache.log4j.PatternLayout\n\n# Pattern format: Date LogLevel LoggerName LogMessage\n#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n\n# Debugging Pattern format\nlog4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p [%t]: %c{2} (%F:%M(%L)) - %m%n\n\n\n#\n# console\n# Add \"console\" to rootlogger above if you want to use this\n#\n\nlog4j.appender.console=org.apache.log4j.ConsoleAppender\nlog4j.appender.console.target=System.err\nlog4j.appender.console.layout=org.apache.log4j.PatternLayout\nlog4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} [%t]: %p %c{2}: %m%n\nlog4j.appender.console.encoding=UTF-8\n\n#custom logging levels\n#log4j.logger.xxx=DEBUG\n\n#\n# Event Counter Appender\n# Sends counts of logging messages at different severity levels to Hadoop Metrics.\n#\nlog4j.appender.EventCounter=org.apache.hadoop.hive.shims.HiveEventCounter\n\n\nlog4j.category.DataNucleus=ERROR,DRFA\nlog4j.category.Datastore=ERROR,DRFA\nlog4j.category.Datastore.Schema=ERROR,DRFA\nlog4j.category.JPOX.Datastore=ERROR,DRFA\nlog4j.category.JPOX.Plugin=ERROR,DRFA\nlog4j.category.JPOX.MetaData=ERROR,DRFA\nlog4j.category.JPOX.Query=ERROR,DRFA\nlog4j.category.JPOX.General=ERROR,DRFA\nlog4j.category.JPOX.Enhancer=ERROR,DRFA\n\n\n# Silence useless ZK logs\nlog4j.logger.org.apache.zookeeper.server.NIOServerCnxn=WARN,DRFA\nlog4j.logger.org.apache.zookeeper.ClientCnxnSocketNIO=WARN,DRFA"
+        }
+      }
+    },
+    {
+      "hive-site": {
+        "properties": {
+          "ambari.hive.db.schema.name": "hive",
+          "datanucleus.cache.level2.type": "none",
+          "hive.auto.convert.join": "true",
+          "hive.auto.convert.join.noconditionaltask": "true",
+          "hive.auto.convert.join.noconditionaltask.size": "238026752",
+          "hive.auto.convert.sortmerge.join": "true",
+          "hive.auto.convert.sortmerge.join.to.mapjoin": "false",
+          "hive.cbo.enable": "true",
+          "hive.cli.print.header": "false",
+          "hive.cluster.delegation.token.store.class": "org.apache.hadoop.hive.thrift.ZooKeeperTokenStore",
+          "hive.cluster.delegation.token.store.zookeeper.connectString": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181",
+          "hive.cluster.delegation.token.store.zookeeper.znode": "/hive/cluster/delegation",
+          "hive.compactor.abortedtxn.threshold": "1000",
+          "hive.compactor.check.interval": "300L",
+          "hive.compactor.delta.num.threshold": "10",
+          "hive.compactor.delta.pct.threshold": "0.1f",
+          "hive.compactor.initiator.on": "false",
+          "hive.compactor.worker.threads": "0",
+          "hive.compactor.worker.timeout": "86400L",
+          "hive.compute.query.using.stats": "true",
+          "hive.conf.restricted.list": "hive.security.authenticator.manager,hive.security.authorization.manager,hive.users.in.admin.role",
+          "hive.convert.join.bucket.mapjoin.tez": "false",
+          "hive.enforce.bucketing": "true",
+          "hive.enforce.sorting": "true",
+          "hive.enforce.sortmergebucketmapjoin": "true",
+          "hive.exec.compress.intermediate": "false",
+          "hive.exec.compress.output": "false",
+          "hive.exec.dynamic.partition": "true",
+          "hive.exec.dynamic.partition.mode": "nonstrict",
+          "hive.exec.failure.hooks": "org.apache.hadoop.hive.ql.hooks.ATSHook",
+          "hive.exec.max.created.files": "100000",
+          "hive.exec.max.dynamic.partitions": "5000",
+          "hive.exec.max.dynamic.partitions.pernode": "2000",
+          "hive.exec.orc.compression.strategy": "SPEED",
+          "hive.exec.orc.default.compress": "ZLIB",
+          "hive.exec.orc.default.stripe.size": "67108864",
+          "hive.exec.parallel": "false",
+          "hive.exec.parallel.thread.number": "8",
+          "hive.exec.post.hooks": "org.apache.hadoop.hive.ql.hooks.ATSHook",
+          "hive.exec.pre.hooks": "org.apache.hadoop.hive.ql.hooks.ATSHook",
+          "hive.exec.reducers.bytes.per.reducer": "67108864",
+          "hive.exec.reducers.max": "1009",
+          "hive.exec.scratchdir": "/tmp/hive",
+          "hive.exec.submit.local.task.via.child": "true",
+          "hive.exec.submitviachild": "false",
+          "hive.execution.engine": "tez",
+          "hive.fetch.task.aggr": "false",
+          "hive.fetch.task.conversion": "more",
+          "hive.fetch.task.conversion.threshold": "1073741824",
+          "hive.limit.optimize.enable": "true",
+          "hive.limit.pushdown.memory.usage": "0.04",
+          "hive.map.aggr": "true",
+          "hive.map.aggr.hash.force.flush.memory.threshold": "0.9",
+          "hive.map.aggr.hash.min.reduction": "0.5",
+          "hive.map.aggr.hash.percentmemory": "0.5",
+          "hive.mapjoin.bucket.cache.size": "10000",
+          "hive.mapjoin.optimized.hashtable": "true",
+          "hive.mapred.reduce.tasks.speculative.execution": "false",
+          "hive.merge.mapfiles": "true",
+          "hive.merge.mapredfiles": "false",
+          "hive.merge.orcfile.stripe.level": "true",
+          "hive.merge.rcfile.block.level": "true",
+          "hive.merge.size.per.task": "256000000",
+          "hive.merge.smallfiles.avgsize": "16000000",
+          "hive.merge.tezfiles": "false",
+          "hive.metastore.authorization.storage.checks": "false",
+          "hive.metastore.cache.pinobjtypes": "Table,Database,Type,FieldSchema,Order",
+          "hive.metastore.client.connect.retry.delay": "5s",
+          "hive.metastore.client.socket.timeout": "1800s",
+          "hive.metastore.connect.retries": "24",
+          "hive.metastore.execute.setugi": "true",
+          "hive.metastore.failure.retries": "24",
+          "hive.metastore.kerberos.keytab.file": "/etc/security/keytabs/hive.service.keytab",
+          "hive.metastore.kerberos.principal": "hive/_HOST@EXAMPLE.COM",
+          "hive.metastore.pre.event.listeners": "org.apache.hadoop.hive.ql.security.authorization.AuthorizationPreEventListener",
+          "hive.metastore.sasl.enabled": "false",
+          "hive.metastore.server.max.threads": "100000",
+          "hive.metastore.uris": "thrift://%HOSTGROUP::host_group_master_2%:9083",
+          "hive.metastore.warehouse.dir": "/apps/hive/warehouse",
+          "hive.optimize.bucketmapjoin": "true",
+          "hive.optimize.bucketmapjoin.sortedmerge": "false",
+          "hive.optimize.constant.propagation": "true",
+          "hive.optimize.index.filter": "true",
+          "hive.optimize.metadataonly": "true",
+          "hive.optimize.null.scan": "true",
+          "hive.optimize.reducededuplication": "true",
+          "hive.optimize.reducededuplication.min.reducer": "4",
+          "hive.optimize.sort.dynamic.partition": "false",
+          "hive.orc.compute.splits.num.threads": "10",
+          "hive.orc.splits.include.file.footer": "false",
+          "hive.prewarm.enabled": "false",
+          "hive.prewarm.numcontainers": "10",
+          "hive.security.authenticator.manager": "org.apache.hadoop.hive.ql.security.ProxyUserAuthenticator",
+          "hive.security.authorization.enabled": "false",
+          "hive.security.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdConfOnlyAuthorizerFactory",
+          "hive.security.metastore.authenticator.manager": "org.apache.hadoop.hive.ql.security.HadoopDefaultMetastoreAuthenticator",
+          "hive.security.metastore.authorization.auth.reads": "true",
+          "hive.security.metastore.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.StorageBasedAuthorizationProvider,org.apache.hadoop.hive.ql.security.authorization.MetaStoreAuthzAPIAuthorizerEmbedOnly",
+          "hive.server2.allow.user.substitution": "true",
+          "hive.server2.authentication": "NONE",
+          "hive.server2.authentication.spnego.keytab": "HTTP/_HOST@EXAMPLE.COM",
+          "hive.server2.authentication.spnego.principal": "/etc/security/keytabs/spnego.service.keytab",
+          "hive.server2.enable.doAs": "true",
+          "hive.server2.logging.operation.enabled": "true",
+          "hive.server2.logging.operation.log.location": "${system:java.io.tmpdir}/${system:user.name}/operation_logs",
+          "hive.server2.support.dynamic.service.discovery": "true",
+          "hive.server2.table.type.mapping": "CLASSIC",
+          "hive.server2.tez.default.queues": "default",
+          "hive.server2.tez.initialize.default.sessions": "false",
+          "hive.server2.tez.sessions.per.default.queue": "1",
+          "hive.server2.thrift.http.path": "cliservice",
+          "hive.server2.thrift.http.port": "10001",
+          "hive.server2.thrift.max.worker.threads": "500",
+          "hive.server2.thrift.port": "10000",
+          "hive.server2.thrift.sasl.qop": "auth",
+          "hive.server2.transport.mode": "binary",
+          "hive.server2.use.SSL": "false",
+          "hive.server2.zookeeper.namespace": "hiveserver2",
+          "hive.smbjoin.cache.rows": "10000",
+          "hive.stats.autogather": "true",
+          "hive.stats.dbclass": "fs",
+          "hive.stats.fetch.column.stats": "false",
+          "hive.stats.fetch.partition.stats": "true",
+          "hive.support.concurrency": "false",
+          "hive.tez.auto.reducer.parallelism": "false",
+          "hive.tez.container.size": "682",
+          "hive.tez.cpu.vcores": "-1",
+          "hive.tez.dynamic.partition.pruning": "true",
+          "hive.tez.dynamic.partition.pruning.max.data.size": "104857600",
+          "hive.tez.dynamic.partition.pruning.max.event.size": "1048576",
+          "hive.tez.input.format": "org.apache.hadoop.hive.ql.io.HiveInputFormat",
+          "hive.tez.java.opts": "-server -Xmx546m -Djava.net.preferIPv4Stack=true -XX:NewRatio=8 -XX:+UseNUMA -XX:+UseParallelGC -XX:+PrintGCDetails -verbose:gc -XX:+PrintGCTimeStamps",
+          "hive.tez.log.level": "INFO",
+          "hive.tez.max.partition.factor": "2.0",
+          "hive.tez.min.partition.factor": "0.25",
+          "hive.tez.smb.number.waves": "0.5",
+          "hive.txn.manager": "org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager",
+          "hive.txn.max.open.batch": "1000",
+          "hive.txn.timeout": "300",
+          "hive.user.install.directory": "/user/",
+          "hive.vectorized.execution.enabled": "true",
+          "hive.vectorized.execution.reduce.enabled": "false",
+          "hive.vectorized.groupby.checkinterval": "4096",
+          "hive.vectorized.groupby.flush.percent": "0.1",
+          "hive.vectorized.groupby.maxentries": "100000",
+          "hive.zookeeper.client.port": "2181",
+          "hive.zookeeper.namespace": "hive_zookeeper_namespace",
+          "hive.zookeeper.quorum": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181",
+          "javax.jdo.option.ConnectionDriverName": "com.mysql.jdbc.Driver",
+          "javax.jdo.option.ConnectionURL": "jdbc:mysql://%HOSTGROUP::host_group_master_2%/hive?createDatabaseIfNotExist=true",
+          "javax.jdo.option.ConnectionUserName": "hive"
+        }
+      }
+    },
+    {
+      "hiveserver2-site": {
+        "properties": {
+          "hive.security.authenticator.manager": "org.apache.hadoop.hive.ql.security.SessionStateUserAuthenticator",
+          "hive.security.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory"
+        }
+      }
+    },
+    {
+      "kafka-broker": {
+        "properties": {
+          "auto.create.topics.enable": "true",
+          "controlled.shutdown.enable": "false",
+          "controlled.shutdown.max.retries": "3",
+          "controlled.shutdown.retry.backoff.ms": "5000",
+          "controller.message.queue.size": "10",
+          "controller.socket.timeout.ms": "30000",
+          "default.replication.factor": "1",
+          "fetch.purgatory.purge.interval.requests": "10000",
+          "kafka.ganglia.metrics.group": "kafka",
+          "kafka.ganglia.metrics.port": "8671",
+          "kafka.ganglia.metrics.reporter.enabled": "true",
+          "kafka.metrics.reporters": "{{kafka_metrics_reporters}}",
+          "kafka.timeline.metrics.host": "{{metric_collector_host}}",
+          "kafka.timeline.metrics.maxRowCacheSize": "10000",
+          "kafka.timeline.metrics.port": "{{metric_collector_port}}",
+          "kafka.timeline.metrics.reporter.enabled": "true",
+          "kafka.timeline.metrics.reporter.sendInterval": "5900",
+          "log.cleanup.interval.mins": "10",
+          "log.dirs": "/mnt/kafka-logs",
+          "log.flush.interval.messages": "10000",
+          "log.flush.interval.ms": "3000",
+          "log.flush.scheduler.interval.ms": "3000",
+          "log.index.interval.bytes": "4096",
+          "log.index.size.max.bytes": "10485760",
+          "log.retention.bytes": "-1",
+          "log.retention.hours": "168",
+          "log.roll.hours": "168",
+          "log.segment.bytes": "1073741824",
+          "message.max.bytes": "1000000",
+          "num.io.threads": "8",
+          "num.network.threads": "3",
+          "num.partitions": "1",
+          "num.replica.fetchers": "1",
+          "port": "6667",
+          "producer.purgatory.purge.interval.requests": "10000",
+          "queued.max.requests": "500",
+          "replica.fetch.max.bytes": "1048576",
+          "replica.fetch.min.bytes": "1",
+          "replica.fetch.wait.max.ms": "500",
+          "replica.high.watermark.checkpoint.interval.ms": "5000",
+          "replica.lag.max.messages": "4000",
+          "replica.lag.time.max.ms": "10000",
+          "replica.socket.receive.buffer.bytes": "65536",
+          "replica.socket.timeout.ms": "30000",
+          "socket.receive.buffer.bytes": "102400",
+          "socket.request.max.bytes": "104857600",
+          "socket.send.buffer.bytes": "102400",
+          "zookeeper.connect": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181",
+          "zookeeper.connection.timeout.ms": "6000",
+          "zookeeper.session.timeout.ms": "30000",
+          "zookeeper.sync.time.ms": "2000"
+        }
+      }
+    },
+    {
+      "kafka-env": {
+        "properties": {
+          "content": "\n#!/bin/bash\n\n# Set KAFKA specific environment variables here.\n\n# The java implementation to use.\nexport JAVA_HOME={{java64_home}}\nexport PATH=$PATH:$JAVA_HOME/bin\nexport PID_DIR={{kafka_pid_dir}}\nexport LOG_DIR={{kafka_log_dir}}\n\n# Add kafka sink to classpath and related depenencies\nif [ -e \"/usr/lib/ambari-metrics-kafka-sink/ambari-metrics-kafka-sink.jar\" ]; then\n  export CLASSPATH=$CLASSPATH:/usr/lib/ambari-metrics-kafka-sink/ambari-metrics-kafka-sink.jar\n  export CLASSPATH=$CLASSPATH:/usr/lib/ambari-metrics-kafka-sink/lib/*\nfi",
+          "kafka_log_dir": "/var/log/kafka",
+          "kafka_pid_dir": "/var/run/kafka",
+          "kafka_user": "kafka"
+        }
+      }
+    },
+    {
+      "kafka-log4j": {
+        "properties": {
+          "content": "\n#\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n#\n#\nkafka.logs.dir=logs\n\nlog4j.rootLogger=INFO, stdout\n\nlog4j.appender.stdout=org.apache.log4j.ConsoleAppender\nlog4j.appender.stdout.layout=org.apache.log4j.PatternLayout\nlog4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log\nlog4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.stateChangeAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log\nlog4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log\nlog4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.cleanerAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log\nlog4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\nlog4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log\nlog4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout\nlog4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n\n\n# Turn on all our debugging info\n#log4j.logger.kafka.producer.async.DefaultEventHandler=DEBUG, kafkaAppender\n#log4j.logger.kafka.client.ClientUtils=DEBUG, kafkaAppender\n#log4j.logger.kafka.perf=DEBUG, kafkaAppender\n#log4j.logger.kafka.perf.ProducerPerformance$ProducerThread=DEBUG, kafkaAppender\n#log4j.logger.org.I0Itec.zkclient.ZkClient=DEBUG\nlog4j.logger.kafka=INFO, kafkaAppender\nlog4j.logger.kafka.network.RequestChannel$=WARN, requestAppender\nlog4j.additivity.kafka.network.RequestChannel$=false\n\n#log4j.logger.kafka.network.Processor=TRACE, requestAppender\n#log4j.logger.kafka.server.KafkaApis=TRACE, requestAppender\n#log4j.additivity.kafka.server.KafkaApis=false\nlog4j.logger.kafka.request.logger=WARN, requestAppender\nlog4j.additivity.kafka.request.logger=false\n\nlog4j.logger.kafka.controller=TRACE, controllerAppender\nlog4j.additivity.kafka.controller=false\n\nlog4j.logger.kafka.log.LogCleaner=INFO, cleanerAppender\nlog4j.additivity.kafka.log.LogCleaner=false\n\nlog4j.logger.state.change.logger=TRACE, stateChangeAppender\nlog4j.additivity.state.change.logger=false"
+        }
+      }
+    },
+    {
+      "knox-env": {
+        "properties": {
+          "knox_group": "knox",
+          "knox_pid_dir": "/var/run/knox",
+          "knox_user": "knox"
+        }
+      }
+    },
+    {
+      "ldap-log4j": {
+        "properties": {
+          "content": "\n        # Licensed to the Apache Software Foundation (ASF) under one\n        # or more contributor license agreements.  See the NOTICE file\n        # distributed with this work for additional information\n        # regarding copyright ownership.  The ASF licenses this file\n        # to you under the Apache License, Version 2.0 (the\n        # \"License\"); you may not use this file except in compliance\n        # with the License.  You may obtain a copy of the License at\n        #\n        #     http://www.apache.org/licenses/LICENSE-2.0\n        #\n        # Unless required by applicable law or agreed to in writing, software\n        # distributed under the License is distributed on an \"AS IS\" BASIS,\n        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n        # See the License for the specific language governing permissions and\n        # limitations under the License.\n\n        app.log.dir=${launcher.dir}/../logs\n        app.log.file=${launcher.name}.log\n\n        log4j.rootLogger=ERROR, drfa\n        log4j.logger.org.apache.directory.server.ldap.LdapServer=INFO\n        log4j.logger.org.apache.directory=WARN\n\n        log4j.appender.stdout=org.apache.log4j.ConsoleAppender\n        log4j.appender.stdout.layout=org.apache.log4j.PatternLayout\n        log4j.appender.stdout.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\n\n        log4j.appender.drfa=org.apache.log4j.DailyRollingFileAppender\n        log4j.appender.drfa.File=${app.log.dir}/${app.log.file}\n        log4j.appender.drfa.DatePattern=.yyyy-MM-dd\n        log4j.appender.drfa.layout=org.apache.log4j.PatternLayout\n        log4j.appender.drfa.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n"
+        }
+      }
+    },
+    {
+      "mapred-env": {
+        "properties": {
+          "content": "\n# export JAVA_HOME=/home/y/libexec/jdk1.6.0/\n\nexport HADOOP_JOB_HISTORYSERVER_HEAPSIZE={{jobhistory_heapsize}}\n\nexport HADOOP_MAPRED_ROOT_LOGGER=INFO,RFA\n\n#export HADOOP_JOB_HISTORYSERVER_OPTS=\n#export HADOOP_MAPRED_LOG_DIR=\"\" # Where log files are stored.  $HADOOP_MAPRED_HOME/logs by default.\n#export HADOOP_JHS_LOGGER=INFO,RFA # Hadoop JobSummary logger.\n#export HADOOP_MAPRED_PID_DIR= # The pid files are stored. /tmp by default.\n#export HADOOP_MAPRED_IDENT_STRING= #A string representing this instance of hadoop. $USER by default\n#export HADOOP_MAPRED_NICENESS= #The scheduling priority for daemons. Defaults to 0.\nexport HADOOP_OPTS=\"-Dhdp.version=$HDP_VERSION $HADOOP_OPTS\"",
+          "jobhistory_heapsize": "900",
+          "mapred_log_dir_prefix": "/var/log/hadoop-mapreduce",
+          "mapred_pid_dir_prefix": "/var/run/hadoop-mapreduce",
+          "mapred_user": "mapred"
+        }
+      }
+    },
+    {
+      "mapred-site": {
+        "properties": {
+          "mapreduce.admin.map.child.java.opts": "-server -XX:NewRatio=8 -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}",
+          "mapreduce.admin.reduce.child.java.opts": "-server -XX:NewRatio=8 -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}",
+          "mapreduce.admin.user.env": "LD_LIBRARY_PATH=/usr/hdp/${hdp.version}/hadoop/lib/native:/usr/hdp/${hdp.version}/hadoop/lib/native/Linux-amd64-64",
+          "mapreduce.am.max-attempts": "2",
+          "mapreduce.application.classpath": "$PWD/mr-framework/hadoop/share/hadoop/mapreduce/*:$PWD/mr-framework/hadoop/share/hadoop/mapreduce/lib/*:$PWD/mr-framework/hadoop/share/hadoop/common/*:$PWD/mr-framework/hadoop/share/hadoop/common/lib/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/lib/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/lib/*:/usr/hdp/${hdp.version}/hadoop/lib/hadoop-lzo-0.6.0.${hdp.version}.jar:/etc/hadoop/conf/secure",
+          "mapreduce.application.framework.path": "/hdp/apps/${hdp.version}/mapreduce/mapreduce.tar.gz#mr-framework",
+          "mapreduce.cluster.administrators": " hadoop",
+          "mapreduce.framework.name": "yarn",
+          "mapreduce.job.emit-timeline-data": "false",
+          "mapreduce.job.reduce.slowstart.completedmaps": "0.05",
+          "mapreduce.jobhistory.address": "%HOSTGROUP::host_group_master_1%:10020",
+          "mapreduce.jobhistory.bind-host": "0.0.0.0",
+          "mapreduce.jobhistory.done-dir": "/mr-history/done",
+          "mapreduce.jobhistory.intermediate-done-dir": "/mr-history/tmp",
+          "mapreduce.jobhistory.webapp.address": "%HOSTGROUP::host_group_master_1%:19888",
+          "mapreduce.map.java.opts": "-Xmx546m",
+          "mapreduce.map.log.level": "INFO",
+          "mapreduce.map.memory.mb": "682",
+          "mapreduce.map.output.compress": "false",
+          "mapreduce.map.sort.spill.percent": "0.7",
+          "mapreduce.map.speculative": "false",
+          "mapreduce.output.fileoutputformat.compress": "false",
+          "mapreduce.output.fileoutputformat.compress.type": "BLOCK",
+          "mapreduce.reduce.input.buffer.percent": "0.0",
+          "mapreduce.reduce.java.opts": "-Xmx546m",
+          "mapreduce.reduce.log.level": "INFO",
+          "mapreduce.reduce.memory.mb": "682",
+          "mapreduce.reduce.shuffle.fetch.retry.enabled": "1",
+          "mapreduce.reduce.shuffle.fetch.retry.interval-ms": "1000",
+          "mapreduce.reduce.shuffle.fetch.retry.timeout-ms": "30000",
+          "mapreduce.reduce.shuffle.input.buffer.percent": "0.7",
+          "mapreduce.reduce.shuffle.merge.percent": "0.66",
+          "mapreduce.reduce.shuffle.parallelcopies": "30",
+          "mapreduce.reduce.speculative": "false",
+          "mapreduce.shuffle.port": "13562",
+          "mapreduce.task.io.sort.factor": "100",
+          "mapreduce.task.io.sort.mb": "273",
+          "mapreduce.task.timeout": "300000",
+          "yarn.app.mapreduce.am.admin-command-opts": "-Dhdp.version=${hdp.version}",
+          "yarn.app.mapreduce.am.command-opts": "-Xmx546m -Dhdp.version=${hdp.version}",
+          "yarn.app.mapreduce.am.log.level": "INFO",
+          "yarn.app.mapreduce.am.resource.mb": "682",
+          "yarn.app.mapreduce.am.staging-dir": "/user"
+        }
+      }
+    },
+    {
+      "oozie-env": {
+        "properties": {
+          "content": "\n#!/bin/bash\n\nif [ -d \"/usr/lib/bigtop-tomcat\" ]; then\n  export OOZIE_CONFIG=${OOZIE_CONFIG:-/etc/oozie/conf}\n  export CATALINA_BASE=${CATALINA_BASE:-{{oozie_server_dir}}}\n  export CATALINA_TMPDIR=${CATALINA_TMPDIR:-/var/tmp/oozie}\n  export OOZIE_CATALINA_HOME=/usr/lib/bigtop-tomcat\nfi\n\n#Set JAVA HOME\nexport JAVA_HOME={{java_home}}\n\nexport JRE_HOME=${JAVA_HOME}\n\n# Set Oozie specific environment variables here.\n\n# Settings for the Embedded Tomcat that runs Oozie\n# Java System properties for Oozie should be specified in this variable\n#\n# export CATALINA_OPTS=\n\n# Oozie configuration file to load from Oozie configuration directory\n#\n# export OOZIE_CONFIG_FILE=oozie-site.xml\n\n# Oozie logs directory\n#\nexport OOZIE_LOG={{oozie_log_dir}}\n\n# Oozie pid directory\n#\nexport CATALINA_PID={{pid_file}}\n\n#Location of the data for oozie\nexport OOZIE_DATA={{oozie_data_dir}}\n\n# Oozie Log4J configuration file to load from Oozie configuration directory\n#\n# export OOZIE_LOG4J_FILE=oozie-log4j.properties\n\n# Reload interval of the Log4J configuration file, in seconds\n#\n# export OOZIE_LOG4J_RELOAD=10\n\n# The port Oozie server runs\n#\nexport OOZIE_HTTP_PORT={{oozie_server_port}}\n\n# The admin port Oozie server runs\n#\nexport OOZIE_ADMIN_PORT={{oozie_server_admin_port}}\n\n# The host name Oozie server runs on\n#\n# export OOZIE_HTTP_HOSTNAME=`hostname -f`\n\n# The base URL for callback URLs to Oozie\n#\n# export OOZIE_BASE_URL=\"http://${OOZIE_HTTP_HOSTNAME}:${OOZIE_HTTP_PORT}/oozie\"\nexport JAVA_LIBRARY_PATH={{hadoop_lib_home}}/native/Linux-amd64-64\n\n# At least 1 minute of retry time to account for server downtime during\n# upgrade/downgrade\nexport OOZIE_CLIENT_OPTS=\"${OOZIE_CLIENT_OPTS} -Doozie.connection.retry.count=5 \"\n\n# This is needed so that Oozie does not run into OOM or GC Overhead limit\n# exceeded exceptions. If the oozie server is handling large number of\n# workflows/coordinator jobs, the memory settings may need to be revised\nexport CATALINA_OPTS=\"${CATALINA_OPTS} -Xmx2048m -XX:MaxPermSize=256m \"",
+          "oozie_admin_port": "11001",
+          "oozie_data_dir": "/mnt/hadoop/oozie/data",
+          "oozie_database": "New Derby Database",
+          "oozie_derby_database": "Derby",
+          "oozie_existing_oracle_host": "",
+          "oozie_existing_postgresql_host": "",
+          "oozie_heapsize": "2048m",
+          "oozie_hostname": "%HOSTGROUP::host_group_master_1%",
+          "oozie_log_dir": "/var/log/oozie",
+          "oozie_permsize": "256m",
+          "oozie_pid_dir": "/var/run/oozie",
+          "oozie_user": "oozie"
+        }
+      }
+    },
+    {
+      "oozie-log4j": {
+        "properties": {
+          "content": "\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#    http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License. See accompanying LICENSE file.\n#\n\n# If the Java System property 'oozie.log.dir' is not defined at Oozie start up time\n# XLogService sets its value to '${oozie.home}/logs'\n\nlog4j.appender.oozie=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.oozie.DatePattern='.'yyyy-MM-dd-HH\nlog4j.appender.oozie.File=${oozie.log.dir}/oozie.log\nlog4j.appender.oozie.Append=true\nlog4j.appender.oozie.layout=org.apache.log4j.PatternLayout\nlog4j.appender.oozie.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - SERVER[${oozie.instance.id}] %m%n\n\nlog4j.appender.oozieops=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.oozieops.DatePattern='.'yyyy-MM-dd\nlog4j.appender.oozieops.File=${oozie.log.dir}/oozie-ops.log\nlog4j.appender.oozieops.Append=true\nlog4j.appender.oozieops.layout=org.apache.log4j.PatternLayout\nlog4j.appender.oozieops.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - %m%n\n\nlog4j.appender.oozieinstrumentation=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.oozieinstrumentation.DatePattern='.'yyyy-MM-dd\nlog4j.appender.oozieinstrumentation.File=${oozie.log.dir}/oozie-instrumentation.log\nlog4j.appender.oozieinstrumentation.Append=true\nlog4j.appender.oozieinstrumentation.layout=org.apache.log4j.PatternLayout\nlog4j.appender.oozieinstrumentation.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - %m%n\n\nlog4j.appender.oozieaudit=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.oozieaudit.DatePattern='.'yyyy-MM-dd\nlog4j.appender.oozieaudit.File=${oozie.log.dir}/oozie-audit.log\nlog4j.appender.oozieaudit.Append=true\nlog4j.appender.oozieaudit.layout=org.apache.log4j.PatternLayout\nlog4j.appender.oozieaudit.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - %m%n\n\nlog4j.appender.openjpa=org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.openjpa.DatePattern='.'yyyy-MM-dd\nlog4j.appender.openjpa.File=${oozie.log.dir}/oozie-jpa.log\nlog4j.appender.openjpa.Append=true\nlog4j.appender.openjpa.layout=org.apache.log4j.PatternLayout\nlog4j.appender.openjpa.layout.ConversionPattern=%d{ISO8601} %5p %c{1}:%L - %m%n\n\nlog4j.logger.openjpa=INFO, openjpa\nlog4j.logger.oozieops=INFO, oozieops\nlog4j.logger.oozieinstrumentation=ALL, oozieinstrumentation\nlog4j.logger.oozieaudit=ALL, oozieaudit\nlog4j.logger.org.apache.oozie=INFO, oozie\nlog4j.logger.org.apache.hadoop=WARN, oozie\nlog4j.logger.org.mortbay=WARN, oozie\nlog4j.logger.org.hsqldb=WARN, oozie\nlog4j.logger.org.apache.hadoop.security.authentication.server=INFO, oozie"
+        }
+      }
+    },
+    {
+      "oozie-site": {
+        "properties": {
+          "oozie.authentication.kerberos.name.rules": "\n      RULE:[2:$1@$0]([jt]t@.*TODO-KERBEROS-DOMAIN)s/.*/TODO-MAPREDUSER/\n      RULE:[2:$1@$0]([nd]n@.*TODO-KERBEROS-DOMAIN)s/.*/TODO-HDFSUSER/\n      RULE:[2:$1@$0](hm@.*TODO-KERBEROS-DOMAIN)s/.*/TODO-HBASE-USER/\n      RULE:[2:$1@$0](rs@.*TODO-KERBEROS-DOMAIN)s/.*/TODO-HBASE-USER/\n      DEFAULT",
+          "oozie.authentication.simple.anonymous.allowed": "true",
+          "oozie.authentication.type": "simple",
+          "oozie.base.url": "http://%HOSTGROUP::host_group_master_1%:11000/oozie",
+          "oozie.credentials.credentialclasses": "hcat=org.apache.oozie.action.hadoop.HCatCredentials",
+          "oozie.db.schema.name": "oozie",
+          "oozie.service.ActionService.executor.ext.classes": "\n      org.apache.oozie.action.email.EmailActionExecutor,\n      org.apache.oozie.action.hadoop.HiveActionExecutor,\n      org.apache.oozie.action.hadoop.ShellActionExecutor,\n      org.apache.oozie.action.hadoop.SqoopActionExecutor,\n      org.apache.oozie.action.hadoop.DistcpActionExecutor",
+          "oozie.service.AuthorizationService.security.enabled": "true",
+          "oozie.service.CallableQueueService.callable.concurrency": "3",
+          "oozie.service.CallableQueueService.queue.size": "1000",
+          "oozie.service.CallableQueueService.threads": "10",
+          "oozie.service.ELService.ext.functions.coord-action-create": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph2_now,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph2_today,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph2_yesterday,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_currentMonth,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_lastMonth,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph2_currentYear,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph2_lastYear,\n      latest=org.apache.oozie.coord.CoordELFunctions#ph2_coord_latest_echo,\n      future=org.apache.oozie.coord.CoordELFunctions#ph2_coord_future_echo,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph2_coord_formatTime,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.ELService.ext.functions.coord-action-create-inst": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph2_now_inst,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph2_today_inst,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph2_yesterday_inst,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_currentMonth_inst,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_lastMonth_inst,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph2_currentYear_inst,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph2_lastYear_inst,\n      latest=org.apache.oozie.coord.CoordELFunctions#ph2_coord_latest_echo,\n      future=org.apache.oozie.coord.CoordELFunctions#ph2_coord_future_echo,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph2_coord_formatTime,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.ELService.ext.functions.coord-action-start": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph2_now,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph2_today,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph2_yesterday,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_currentMonth,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph2_lastMonth,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph2_currentYear,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph2_lastYear,\n      latest=org.apache.oozie.coord.CoordELFunctions#ph3_coord_latest,\n      future=org.apache.oozie.coord.CoordELFunctions#ph3_coord_future,\n      dataIn=org.apache.oozie.extensions.OozieELExtensions#ph3_dataIn,\n      instanceTime=org.apache.oozie.coord.CoordELFunctions#ph3_coord_nominalTime,\n      dateOffset=org.apache.oozie.coord.CoordELFunctions#ph3_coord_dateOffset,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph3_coord_formatTime,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.ELService.ext.functions.coord-job-submit-data": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph1_now_echo,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph1_today_echo,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph1_yesterday_echo,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph1_currentMonth_echo,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph1_lastMonth_echo,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph1_currentYear_echo,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph1_lastYear_echo,\n      dataIn=org.apache.oozie.extensions.OozieELExtensions#ph1_dataIn_echo,\n      instanceTime=org.apache.oozie.coord.CoordELFunctions#ph1_coord_nominalTime_echo_wrap,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph1_coord_formatTime_echo,\n      dateOffset=org.apache.oozie.coord.CoordELFunctions#ph1_coord_dateOffset_echo,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.ELService.ext.functions.coord-job-submit-instances": "\n      now=org.apache.oozie.extensions.OozieELExtensions#ph1_now_echo,\n      today=org.apache.oozie.extensions.OozieELExtensions#ph1_today_echo,\n      yesterday=org.apache.oozie.extensions.OozieELExtensions#ph1_yesterday_echo,\n      currentMonth=org.apache.oozie.extensions.OozieELExtensions#ph1_currentMonth_echo,\n      lastMonth=org.apache.oozie.extensions.OozieELExtensions#ph1_lastMonth_echo,\n      currentYear=org.apache.oozie.extensions.OozieELExtensions#ph1_currentYear_echo,\n      lastYear=org.apache.oozie.extensions.OozieELExtensions#ph1_lastYear_echo,\n      formatTime=org.apache.oozie.coord.CoordELFunctions#ph1_coord_formatTime_echo,\n      latest=org.apache.oozie.coord.CoordELFunctions#ph2_coord_latest_echo,\n      future=org.apache.oozie.coord.CoordELFunctions#ph2_coord_future_echo",
+          "oozie.service.ELService.ext.functions.coord-sla-create": "\n      instanceTime=org.apache.oozie.coord.CoordELFunctions#ph2_coord_nominalTime,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.ELService.ext.functions.coord-sla-submit": "\n      instanceTime=org.apache.oozie.coord.CoordELFunctions#ph1_coord_nominalTime_echo_fixed,\n      user=org.apache.oozie.coord.CoordELFunctions#coord_user",
+          "oozie.service.HadoopAccessorService.hadoop.configurations": "*=/etc/hadoop/conf",
+          "oozie.service.HadoopAccessorService.kerberos.enabled": "false",
+          "oozie.service.HadoopAccessorService.supported.filesystems": "*",
+          "oozie.service.JPAService.create.db.schema": "false",
+          "oozie.service.JPAService.jdbc.driver": "org.apache.derby.jdbc.EmbeddedDriver",
+          "oozie.service.JPAService.jdbc.username": "oozie",
+          "oozie.service.JPAService.pool.max.active.conn": "10",
+          "oozie.service.ProxyUserService.proxyuser.falcon.groups": "*",
+          "oozie.service.ProxyUserService.proxyuser.falcon.hosts": "*",
+          "oozie.service.PurgeService.older.than": "30",
+          "oozie.service.PurgeService.purge.interval": "3600",
+          "oozie.service.SchemaService.wf.ext.schemas": "shell-action-0.1.xsd,shell-action-0.2.xsd,shell-action-0.3.xsd,email-action-0.1.xsd,email-action-0.2.xsd,hive-action-0.2.xsd,hive-action-0.3.xsd,hive-action-0.4.xsd,hive-action-0.5.xsd,sqoop-action-0.2.xsd,sqoop-action-0.3.xsd,sqoop-action-0.4.xsd,ssh-action-0.1.xsd,ssh-action-0.2.xsd,distcp-action-0.1.xsd,distcp-action-0.2.xsd,oozie-sla-0.1.xsd,oozie-sla-0.2.xsd",
+          "oozie.service.URIHandlerService.uri.handlers": "org.apache.oozie.dependency.FSURIHandler,org.apache.oozie.dependency.HCatURIHandler",
+          "oozie.service.WorkflowAppService.system.libpath": "/user/${user.name}/share/lib",
+          "oozie.service.coord.check.maximum.frequency": "false",
+          "oozie.service.coord.normal.default.timeout": "120",
+          "oozie.service.coord.push.check.requeue.interval": "30000",
+          "oozie.services": "\n      org.apache.oozie.service.SchedulerService,\n      org.apache.oozie.service.InstrumentationService,\n      org.apache.oozie.service.MemoryLocksService,\n      org.apache.oozie.service.UUIDService,\n      org.apache.oozie.service.ELService,\n      org.apache.oozie.service.AuthorizationService,\n      org.apache.oozie.service.UserGroupInformationService,\n      org.apache.oozie.service.HadoopAccessorService,\n      org.apache.oozie.service.JobsConcurrencyService,\n      org.apache.oozie.service.URIHandlerService,\n      org.apache.oozie.service.DagXLogInfoService,\n      org.apache.oozie.service.SchemaService,\n      org.apache.oozie.service.LiteWorkflowAppService,\n      org.apache.oozie.service.JPAService,\n      org.apache.oozie.service.StoreService,\n      org.apache.oozie.service.CoordinatorStoreService,\n      org.apache.oozie.service.SLAStoreService,\n      org.apache.oozie.service.DBLiteWorkflowStoreService,\n      org.apache.oozie.service.CallbackService,\n      org.apache.oozie.service.ShareLibService,\n      org.apache.oozie.service.CallableQueueService,\n      org.apache.oozie.service.ActionService,\n      org.apache.oozie.service.ActionCheckerService,\n      org.apache.oozie.service.RecoveryService,\n      org.apache.oozie.service.PurgeService,\n      org.apache.oozie.service.CoordinatorEngineService,\n      org.apache.oozie.service.BundleEngineService,\n      org.apache.oozie.service.DagEngineService,\n      org.apache.oozie.service.CoordMaterializeTriggerService,\n      org.apache.oozie.service.StatusTransitService,\n      org.apache.oozie.service.PauseTransitService,\n      org.apache.oozie.service.GroupsService,\n      org.apache.oozie.service.ProxyUserService,\n      org.apache.oozie.service.XLogStreamingService,\n      org.apache.oozie.service.JvmPauseMonitorService",
+          "oozie.services.ext": "org.apache.oozie.service.JMSAccessorService,org.apache.oozie.service.PartitionDependencyManagerService,org.apache.oozie.service.HCatAccessorService",
+          "oozie.system.id": "oozie-${user.name}",
+          "oozie.systemmode": "NORMAL",
+          "use.system.libpath.for.mapreduce.and.pig.jobs": "false"
+        }
+      }
+    },
+    {
+      "pig-env": {
+        "properties": {
+          "content": "\nJAVA_HOME={{java64_home}}\nHADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\nif [ -d \"/usr/lib/tez\" ]; then\n  PIG_OPTS=\"$PIG_OPTS -Dmapreduce.framework.name=yarn\"\nfi"
+        }
+      }
+    },
+    {
+      "pig-log4j": {
+        "properties": {
+          "content": "\n#\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n#\n#\n\n# ***** Set root logger level to DEBUG and its only appender to A.\nlog4j.logger.org.apache.pig=info, A\n\n# ***** A is set to be a ConsoleAppender.\nlog4j.appender.A=org.apache.log4j.ConsoleAppender\n# ***** A uses PatternLayout.\nlog4j.appender.A.layout=org.apache.log4j.PatternLayout\nlog4j.appender.A.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n"
+        }
+      }
+    },
+    {
+      "pig-properties": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n\n# Pig default configuration file. All values can be overwritten by pig.properties and command line arguments.\n# see bin/pig -help\n\n# brief logging (no timestamps)\nbrief=false\n\n# debug level, INFO is default\ndebug=INFO\n\n# verbose print all log messages to screen (default to print only INFO and above to screen)\nverbose=false\n\n# exectype local|mapreduce, mapreduce is default\nexectype=mapreduce\n\n# Enable insertion of information about script into hadoop job conf \npig.script.info.enabled=true\n\n# Do not spill temp files smaller than this size (bytes)\npig.spill.size.threshold=5000000\n\n# EXPERIMENT: Activate garbage collection when spilling a file bigger than this size (bytes)\n# This should help reduce the number of files being spilled.\npig.spill.gc.activation.size=40000000\n\n# the following two parameters are to help estimate the reducer number\npig.exec.reducers.bytes.per.reducer=1000000000\npig.exec.reducers.max=999\n\n# Temporary location to store the intermediate data.\npig.temp.dir=/tmp/\n\n# Threshold for merging FRJoin fragment files\npig.files.concatenation.threshold=100\npig.optimistic.files.concatenation=false;\n\npig.disable.counter=false\n\n# Avoid pig failures when multiple jobs write to the same location\npig.location.check.strict=false\n\nhcat.bin=/usr/bin/hcat"
+        }
+      }
+    },
+    {
+      "ranger-hbase-plugin-properties": {
+        "properties": {
+          "REPOSITORY_CONFIG_PASSWORD": "hbase",
+          "REPOSITORY_CONFIG_USERNAME": "hbase",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "UPDATE_XAPOLICIES_ON_GRANT_REVOKE": "true",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "common.name.for.certificate": "-",
+          "policy_user": "ambari-qa",
+          "ranger-hbase-plugin-enabled": "No"
+        }
+      }
+    },
+    {
+      "ranger-hdfs-plugin-properties": {
+        "properties": {
+          "REPOSITORY_CONFIG_PASSWORD": "hadoop",
+          "REPOSITORY_CONFIG_USERNAME": "hadoop",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "common.name.for.certificate": "-",
+          "hadoop.rpc.protection": "-",
+          "policy_user": "ambari-qa",
+          "ranger-hdfs-plugin-enabled": "No"
+        }
+      }
+    },
+    {
+      "ranger-hive-plugin-properties": {
+        "properties": {
+          "REPOSITORY_CONFIG_PASSWORD": "hive",
+          "REPOSITORY_CONFIG_USERNAME": "hive",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "UPDATE_XAPOLICIES_ON_GRANT_REVOKE": "true",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "common.name.for.certificate": "-",
+          "jdbc.driverClassName": "org.apache.hive.jdbc.HiveDriver",
+          "policy_user": "ambari-qa",
+          "ranger-hive-plugin-enabled": "No"
+        }
+      }
+    },
+    {
+      "ranger-knox-plugin-properties": {
+        "properties": {
+          "KNOX_HOME": "/usr/hdp/current/knox-server",
+          "REPOSITORY_CONFIG_PASSWORD": "admin-password",
+          "REPOSITORY_CONFIG_USERNAME": "admin",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "common.name.for.certificate": "-",
+          "policy_user": "ambari-qa",
+          "ranger-knox-plugin-enabled": "No"
+        }
+      }
+    },
+    {
+      "ranger-storm-plugin-properties": {
+        "properties": {
+          "REPOSITORY_CONFIG_PASSWORD": "stormtestuser",
+          "REPOSITORY_CONFIG_USERNAME": "stormtestuser@EXAMPLE.COM",
+          "SSL_KEYSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-keystore.jks",
+          "SSL_KEYSTORE_PASSWORD": "myKeyFilePassword",
+          "SSL_TRUSTSTORE_FILE_PATH": "/etc/hadoop/conf/ranger-plugin-truststore.jks",
+          "SSL_TRUSTSTORE_PASSWORD": "changeit",
+          "XAAUDIT.DB.IS_ENABLED": "true",
+          "XAAUDIT.HDFS.DESTINATION_DIRECTORY": "hdfs://__REPLACE__NAME_NODE_HOST:8020/ranger/audit/%app-type%/%time:yyyyMMdd%",
+          "XAAUDIT.HDFS.DESTINTATION_FILE": "%hostname%-audit.log",
+          "XAAUDIT.HDFS.DESTINTATION_FLUSH_INTERVAL_SECONDS": "900",
+          "XAAUDIT.HDFS.DESTINTATION_OPEN_RETRY_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.DESTINTATION_ROLLOVER_INTERVAL_SECONDS": "86400",
+          "XAAUDIT.HDFS.IS_ENABLED": "false",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit/archive",
+          "XAAUDIT.HDFS.LOCAL_ARCHIVE_MAX_FILE_COUNT": "10",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_DIRECTORY": "__REPLACE__LOG_DIR/hadoop/%app-type%/audit",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FILE": "%time:yyyyMMdd-HHmm.ss%.log",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_FLUSH_INTERVAL_SECONDS": "60",
+          "XAAUDIT.HDFS.LOCAL_BUFFER_ROLLOVER_INTERVAL_SECONDS": "600",
+          "common.name.for.certificate": "-",
+          "policy_user": "storm",
+          "ranger-storm-plugin-enabled": "No"
+        }
+      }
+    },
+    {
+      "slider-client": {
+        "properties": null
+      }
+    },
+    {
+      "slider-env": {
+        "properties": {
+          "content": "\n# Set Slider-specific environment variables here.\n\n# The only required environment variable is JAVA_HOME.  All others are\n# optional.  When running a distributed configuration it is best to\n# set JAVA_HOME in this file, so that it is correctly defined on\n# remote nodes.\n\n# The java implementation to use.  Required.\nexport JAVA_HOME={{java64_home}}\n# The hadoop conf directory.  Optional as slider-client.xml can be edited to add properties.\nexport HADOOP_CONF_DIR={{hadoop_conf_dir}}"
+        }
+      }
+    },
+    {
+      "slider-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n\n# Define some default values that can be overridden by system properties\nlog4j.rootLogger=INFO,stdout\nlog4j.threshhold=ALL\nlog4j.appender.stdout=org.apache.log4j.ConsoleAppender\nlog4j.appender.stdout.layout=org.apache.log4j.PatternLayout\n\n# log layout skips stack-trace creation operations by avoiding line numbers and method\nlog4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} - %m%n\n\n# debug edition is much more expensive\n#log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n\n\n\nlog4j.appender.subprocess=org.apache.log4j.ConsoleAppender\nlog4j.appender.subprocess.layout=org.apache.log4j.PatternLayout\nlog4j.appender.subprocess.layout.ConversionPattern=[%c{1}]: %m%n\n#log4j.logger.org.apache.slider.yarn.appmaster.SliderAppMasterer.master=INFO,subprocess\n\n# for debugging Slider\n#log4j.logger.org.apache.slider=DEBUG\n#log4j.logger.org.apache.slider=DEBUG\n\n# uncomment to debug service lifecycle issues\n#log4j.logger.org.apache.hadoop.yarn.service.launcher=DEBUG\n#log4j.logger.org.apache.hadoop.yarn.service=DEBUG\n\n# uncomment for YARN operations\n#log4j.logger.org.apache.hadoop.yarn.client=DEBUG\n\n# uncomment this to debug security problems\n#log4j.logger.org.apache.hadoop.security=DEBUG\n\n#crank back on some noise\nlog4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR\nlog4j.logger.org.apache.hadoop.hdfs=WARN\n\n\nlog4j.logger.org.apache.hadoop.yarn.server.nodemanager.containermanager.monitor=WARN\nlog4j.logger.org.apache.hadoop.yarn.server.nodemanager.NodeStatusUpdaterImpl=WARN\nlog4j.logger.org.apache.zookeeper=WARN"
+        }
+      }
+    },
+    {
+      "sqoop-env": {
+        "properties": {
+          "content": "\n# Set Hadoop-specific environment variables here.\n\n#Set path to where bin/hadoop is available\n#Set path to where bin/hadoop is available\nexport HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\n#set the path to where bin/hbase is available\nexport HBASE_HOME=${HBASE_HOME:-{{hbase_home}}}\n\n#Set the path to where bin/hive is available\nexport HIVE_HOME=${HIVE_HOME:-{{hive_home}}}\n\n#Set the path for where zookeper config dir is\nexport ZOOCFGDIR=${ZOOCFGDIR:-/etc/zookeeper/conf}\n\n# add libthrift in hive to sqoop class path first so hive imports work\nexport SQOOP_USER_CLASSPATH=\"`ls ${HIVE_HOME}/lib/libthrift-*.jar 2> /dev/null`:${SQOOP_USER_CLASSPATH}\"",
+          "sqoop_user": "sqoop"
+        }
+      }
+    },
+    {
+      "storm-env": {
+        "properties": {
+          "content": "\n#!/bin/bash\n\n# Set Storm specific environment variables here.\n\n# The java implementation to use.\nexport JAVA_HOME={{java64_home}}\n\n# export STORM_CONF_DIR=\"\"\nexport STORM_HOME=/usr/hdp/current/storm-client",
+          "storm_log_dir": "/var/log/storm",
+          "storm_pid_dir": "/var/run/storm",
+          "storm_user": "storm"
+        }
+      }
+    },
+    {
+      "storm-site": {
+        "properties": {
+          "_storm.min.ruid": "null",
+          "_storm.thrift.nonsecure.transport": "backtype.storm.security.auth.SimpleTransportPlugin",
+          "_storm.thrift.secure.transport": "backtype.storm.security.auth.kerberos.KerberosSaslTransportPlugin",
+          "dev.zookeeper.path": "/tmp/dev-storm-zookeeper",
+          "drpc.childopts": "-Xmx768m _JAAS_PLACEHOLDER",
+          "drpc.invocations.port": "3773",
+          "drpc.port": "3772",
+          "drpc.queue.size": "128",
+          "drpc.request.timeout.secs": "600",
+          "drpc.worker.threads": "64",
+          "java.library.path": "/usr/local/lib:/opt/local/lib:/usr/lib:/usr/hdp/current/storm-client/lib",
+          "logviewer.appender.name": "A1",
+          "logviewer.childopts": "-Xmx128m _JAAS_PLACEHOLDER",
+          "logviewer.port": "8000",
+          "nimbus.cleanup.inbox.freq.secs": "600",
+          "nimbus.file.copy.expiration.secs": "600",
+          "nimbus.host": "%HOSTGROUP::host_group_master_2%",
+          "nimbus.inbox.jar.expiration.secs": "3600",
+          "nimbus.monitor.freq.secs": "10",
+          "nimbus.reassign": "true",
+          "nimbus.supervisor.timeout.secs": "60",
+          "nimbus.task.launch.secs": "120",
+          "nimbus.task.timeout.secs": "30",
+          "nimbus.thrift.max_buffer_size": "1048576",
+          "nimbus.thrift.port": "6627",
+          "nimbus.topology.validator": "backtype.storm.nimbus.DefaultTopologyValidator",
+          "storm.cluster.mode": "distributed",
+          "storm.local.dir": "/mnt/hadoop/storm",
+          "storm.local.mode.zmq": "false",
+          "storm.messaging.netty.buffer_size": "5242880",
+          "storm.messaging.netty.client_worker_threads": "1",
+          "storm.messaging.netty.max_retries": "30",
+          "storm.messaging.netty.max_wait_ms": "1000",
+          "storm.messaging.netty.min_wait_ms": "100",
+          "storm.messaging.netty.server_worker_threads": "1",
+          "storm.messaging.transport": "backtype.storm.messaging.netty.Context",
+          "storm.zookeeper.connection.timeout": "15000",
+          "storm.zookeeper.port": "2181",
+          "storm.zookeeper.retry.interval": "1000",
+          "storm.zookeeper.retry.intervalceiling.millis": "30000",
+          "storm.zookeeper.retry.times": "5",
+          "storm.zookeeper.root": "/storm",
+          "storm.zookeeper.servers": "['%HOSTGROUP::host_group_master_1%','%HOSTGROUP::host_group_master_3%','%HOSTGROUP::host_group_master_2%']",
+          "storm.zookeeper.session.timeout": "20000",
+          "supervisor.heartbeat.frequency.secs": "5",
+          "supervisor.monitor.frequency.secs": "3",
+          "supervisor.slots.ports": "[6700, 6701]",
+          "supervisor.worker.start.timeout.secs": "120",
+          "supervisor.worker.timeout.secs": "30",
+          "task.heartbeat.frequency.secs": "3",
+          "task.refresh.poll.secs": "10",
+          "topology.acker.executors": "null",
+          "topology.builtin.metrics.bucket.size.secs": "60",
+          "topology.debug": "false",
+          "topology.disruptor.wait.strategy": "com.lmax.disruptor.BlockingWaitStrategy",
+          "topology.enable.message.timeouts": "true",
+          "topology.error.throttle.interval.secs": "10",
+          "topology.executor.receive.buffer.size": "1024",
+          "topology.executor.send.buffer.size": "1024",
+          "topology.fall.back.on.java.serialization": "true",
+          "topology.kryo.factory": "backtype.storm.serialization.DefaultKryoFactory",
+          "topology.max.error.report.per.interval": "5",
+          "topology.max.spout.pending": "null",
+          "topology.max.task.parallelism": "null",
+          "topology.message.timeout.secs": "30",
+          "topology.optimize": "true",
+          "topology.receiver.buffer.size": "8",
+          "topology.skip.missing.kryo.registrations": "false",
+          "topology.sleep.spout.wait.strategy.time.ms": "1",
+          "topology.spout.wait.strategy": "backtype.storm.spout.SleepSpoutWaitStrategy",
+          "topology.state.synchronization.timeout.secs": "60",
+          "topology.stats.sample.rate": "0.05",
+          "topology.tick.tuple.freq.secs": "null",
+          "topology.transfer.buffer.size": "1024",
+          "topology.trident.batch.emit.interval.millis": "500",
+          "topology.tuple.serializer": "backtype.storm.serialization.types.ListDelegateSerializer",
+          "topology.worker.childopts": "null",
+          "topology.worker.shared.thread.pool.size": "4",
+          "topology.workers": "1",
+          "transactional.zookeeper.port": "null",
+          "transactional.zookeeper.root": "/transactional",
+          "transactional.zookeeper.servers": "null",
+          "ui.childopts": "-Xmx768m _JAAS_PLACEHOLDER",
+          "ui.filter": "null",
+          "ui.port": "8744",
+          "worker.heartbeat.frequency.secs": "1",
+          "zmq.hwm": "0",
+          "zmq.linger.millis": "5000",
+          "zmq.threads": "1"
+        }
+      }
+    },
+    {
+      "tez-env": {
+        "properties": {
+          "content": "\n# Tez specific configuration\nexport TEZ_CONF_DIR={{config_dir}}\n\n# Set HADOOP_HOME to point to a specific hadoop install directory\nexport HADOOP_HOME=${HADOOP_HOME:-{{hadoop_home}}}\n\n# The java implementation to use.\nexport JAVA_HOME={{java64_home}}",
+          "tez_user": "tez"
+        }
+      }
+    },
+    {
+      "tez-site": {
+        "properties": {
+          "tez.am.am-rm.heartbeat.interval-ms.max": "250",
+          "tez.am.container.idle.release-timeout-max.millis": "20000",
+          "tez.am.container.idle.release-timeout-min.millis": "10000",
+          "tez.am.container.reuse.enabled": "true",
+          "tez.am.container.reuse.locality.delay-allocation-millis": "250",
+          "tez.am.container.reuse.non-local-fallback.enabled": "false",
+          "tez.am.container.reuse.rack-fallback.enabled": "true",
+          "tez.am.launch.cluster-default.cmd-opts": "-server -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}",
+          "tez.am.launch.cmd-opts": "-XX:+PrintGCDetails -verbose:gc -XX:+PrintGCTimeStamps -XX:+UseNUMA -XX:+UseParallelGC",
+          "tez.am.launch.env": "LD_LIBRARY_PATH=/usr/hdp/${hdp.version}/hadoop/lib/native:/usr/hdp/${hdp.version}/hadoop/lib/native/Linux-amd64-64",
+          "tez.am.log.level": "INFO",
+          "tez.am.max.app.attempts": "2",
+          "tez.am.maxtaskfailures.per.node": "10",
+          "tez.am.resource.memory.mb": "1364",
+          "tez.am.tez-ui.history-url.template": "__HISTORY_URL_BASE__?viewPath=%2F%23%2Ftez-app%2F__APPLICATION_ID__",
+          "tez.cluster.additional.classpath.prefix": "/usr/hdp/${hdp.version}/hadoop/lib/hadoop-lzo-0.6.0.${hdp.version}.jar:/etc/hadoop/conf/secure",
+          "tez.counters.max": "2000",
+          "tez.counters.max.groups": "1000",
+          "tez.generate.debug.artifacts": "false",
+          "tez.grouping.max-size": "1073741824",
+          "tez.grouping.min-size": "16777216",
+          "tez.grouping.split-waves": "1.7",
+          "tez.history.logging.service.class": "org.apache.tez.dag.history.logging.ats.ATSHistoryLoggingService",
+          "tez.lib.uris": "/hdp/apps/${hdp.version}/tez/tez.tar.gz",
+          "tez.runtime.compress": "true",
+          "tez.runtime.compress.codec": "org.apache.hadoop.io.compress.SnappyCodec",
+          "tez.runtime.convert.user-payload.to.history-text": "false",
+          "tez.runtime.io.sort.mb": "272",
+          "tez.runtime.unordered.output.buffer.size-mb": "51",
+          "tez.session.am.dag.submit.timeout.secs": "300",
+          "tez.session.client.timeout.secs": "-1",
+          "tez.shuffle-vertex-manager.max-src-fraction": "0.4",
+          "tez.shuffle-vertex-manager.min-src-fraction": "0.2",
+          "tez.staging-dir": "/tmp/${user.name}/staging",
+          "tez.task.am.heartbeat.counter.interval-ms.max": "4000",
+          "tez.task.get-task.sleep.interval-ms.max": "200",
+          "tez.task.launch.cluster-default.cmd-opts": "-server -Djava.net.preferIPv4Stack=true -Dhdp.version=${hdp.version}",
+          "tez.task.launch.cmd-opts": "-XX:+PrintGCDetails -verbose:gc -XX:+PrintGCTimeStamps -XX:+UseNUMA -XX:+UseParallelGC",
+          "tez.task.launch.env": "LD_LIBRARY_PATH=/usr/hdp/${hdp.version}/hadoop/lib/native:/usr/hdp/${hdp.version}/hadoop/lib/native/Linux-amd64-64",
+          "tez.task.max-events-per-heartbeat": "500",
+          "tez.task.resource.memory.mb": "682",
+          "tez.use.cluster.hadoop-libs": "false"
+        }
+      }
+    },
+    {
+      "topology": {
+        "properties": {
+          "content": "\n        <topology>\n\n            <gateway>\n\n                <provider>\n                    <role>authentication</role>\n                    <name>ShiroProvider</name>\n                    <enabled>true</enabled>\n                    <param>\n                        <name>sessionTimeout</name>\n                        <value>30</value>\n                    </param>\n                    <param>\n                        <name>main.ldapRealm</name>\n                        <value>org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm</value>\n                    </param>\n                    <param>\n                        <name>main.ldapRealm.userDnTemplate</name>\n                        <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>\n                    </param>\n                    <param>\n                        <name>main.ldapRealm.contextFactory.url</name>\n                        <value>ldap://{{knox_host_name}}:33389</value>\n                    </param>\n                    <param>\n                        <name>main.ldapRealm.contextFactory.authenticationMechanism</name>\n                        <value>simple</value>\n                    </param>\n                    <param>\n                        <name>urls./**</name>\n                        <value>authcBasic</value>\n                    </param>\n                </provider>\n\n                <provider>\n                    <role>identity-assertion</role>\n                    <name>Default</name>\n                    <enabled>true</enabled>\n                </provider>\n\n                <provider>\n                    <role>authorization</role>\n                    <name>AclsAuthz</name>\n                    <enabled>true</enabled>\n                </provider>\n\n            </gateway>\n\n            <service>\n                <role>NAMENODE</role>\n                <url>hdfs://{{namenode_host}}:{{namenode_rpc_port}}</url>\n            </service>\n\n            <service>\n                <role>JOBTRACKER</role>\n                <url>rpc://{{rm_host}}:{{jt_rpc_port}}</url>\n            </service>\n\n            <service>\n                <role>WEBHDFS</role>\n                <url>http://{{namenode_host}}:{{namenode_http_port}}/webhdfs</url>\n            </service>\n\n            <service>\n                <role>WEBHCAT</role>\n                <url>http://{{webhcat_server_host}}:{{templeton_port}}/templeton</url>\n            </service>\n\n            <service>\n                <role>OOZIE</role>\n                <url>http://{{oozie_server_host}}:{{oozie_server_port}}/oozie</url>\n            </service>\n\n            <service>\n                <role>WEBHBASE</role>\n                <url>http://{{hbase_master_host}}:{{hbase_master_port}}</url>\n            </service>\n\n            <service>\n                <role>HIVE</role>\n                <url>http://{{hive_server_host}}:{{hive_http_port}}/{{hive_http_path}}</url>\n            </service>\n\n            <service>\n                <role>RESOURCEMANAGER</role>\n                <url>http://{{rm_host}}:{{rm_port}}/ws</url>\n            </service>\n        </topology>"
+        }
+      }
+    },
+    {
+      "users-ldif": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nversion: 1\n\n# Please replace with site specific values\ndn: dc=hadoop,dc=apache,dc=org\nobjectclass: organization\nobjectclass: dcObject\no: Hadoop\ndc: hadoop\n\n# Entry for a sample people container\n# Please replace with site specific values\ndn: ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:organizationalUnit\nou: people\n\n# Entry for a sample end user\n# Please replace with site specific values\ndn: uid=guest,ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:person\nobjectclass:organizationalPerson\nobjectclass:inetOrgPerson\ncn: Guest\nsn: User\nuid: guest\nuserPassword:guest-password\n\n# entry for sample user admin\ndn: uid=admin,ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:person\nobjectclass:organizationalPerson\nobjectclass:inetOrgPerson\ncn: Admin\nsn: Admin\nuid: admin\nuserPassword:admin-password\n\n# entry for sample user sam\ndn: uid=sam,ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:person\nobjectclass:organizationalPerson\nobjectclass:inetOrgPerson\ncn: sam\nsn: sam\nuid: sam\nuserPassword:sam-password\n\n# entry for sample user tom\ndn: uid=tom,ou=people,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:person\nobjectclass:organizationalPerson\nobjectclass:inetOrgPerson\ncn: tom\nsn: tom\nuid: tom\nuserPassword:tom-password\n\n# create FIRST Level groups branch\ndn: ou=groups,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass:organizationalUnit\nou: groups\ndescription: generic groups branch\n\n# create the analyst group under groups\ndn: cn=analyst,ou=groups,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass: groupofnames\ncn: analyst\ndescription:analyst  group\nmember: uid=sam,ou=people,dc=hadoop,dc=apache,dc=org\nmember: uid=tom,ou=people,dc=hadoop,dc=apache,dc=org\n\n\n# create the scientist group under groups\ndn: cn=scientist,ou=groups,dc=hadoop,dc=apache,dc=org\nobjectclass:top\nobjectclass: groupofnames\ncn: scientist\ndescription: scientist group\nmember: uid=sam,ou=people,dc=hadoop,dc=apache,dc=org"
+        }
+      }
+    },
+    {
+      "webhcat-env": {
+        "properties": {
+          "content": "\n# The file containing the running pid\nPID_FILE={{webhcat_pid_file}}\n\nTEMPLETON_LOG_DIR={{templeton_log_dir}}/\n\n\nWEBHCAT_LOG_DIR={{templeton_log_dir}}/\n\n# The console error log\nERROR_LOG={{templeton_log_dir}}/webhcat-console-error.log\n\n# The console log\nCONSOLE_LOG={{templeton_log_dir}}/webhcat-console.log\n\n#TEMPLETON_JAR=templeton_jar_name\n\n#HADOOP_PREFIX=hadoop_prefix\n\n#HCAT_PREFIX=hive_prefix\n\n# Set HADOOP_HOME to point to a specific hadoop install directory\nexport HADOOP_HOME={{hadoop_home}}"
+        }
+      }
+    },
+    {
+      "webhcat-log4j": {
+        "properties": {
+          "content": "\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n\n# Define some default values that can be overridden by system properties\nwebhcat.root.logger = INFO, standard\nwebhcat.log.dir = .\nwebhcat.log.file = webhcat.log\n\nlog4j.rootLogger = ${webhcat.root.logger}\n\n# Logging Threshold\nlog4j.threshhold = DEBUG\n\nlog4j.appender.standard  =  org.apache.log4j.DailyRollingFileAppender\nlog4j.appender.standard.File = ${webhcat.log.dir}/${webhcat.log.file}\n\n# Rollver at midnight\nlog4j.appender.DRFA.DatePattern = .yyyy-MM-dd\n\nlog4j.appender.DRFA.layout = org.apache.log4j.PatternLayout\n\nlog4j.appender.standard.layout = org.apache.log4j.PatternLayout\nlog4j.appender.standard.layout.conversionPattern = %-5p | %d{DATE} | %c | %m%n\n\n# Class logging settings\nlog4j.logger.com.sun.jersey = DEBUG\nlog4j.logger.com.sun.jersey.spi.container.servlet.WebComponent = ERROR\nlog4j.logger.org.apache.hadoop = INFO\nlog4j.logger.org.apache.hadoop.conf = WARN\nlog4j.logger.org.apache.zookeeper = WARN\nlog4j.logger.org.eclipse.jetty = INFO"
+        }
+      }
+    },
+    {
+      "webhcat-site": {
+        "properties": {
+          "templeton.exec.timeout": "60000",
+          "templeton.hadoop": "/usr/hdp/current/hadoop-client/bin/hadoop",
+          "templeton.hadoop.conf.dir": "/etc/hadoop/conf",
+          "templeton.hcat": "/usr/hdp/current/hive-client/bin/hcat",
+          "templeton.hcat.home": "hive.tar.gz/hive/hcatalog",
+          "templeton.hive.archive": "hdfs:///hdp/apps/${hdp.version}/hive/hive.tar.gz",
+          "templeton.hive.home": "hive.tar.gz/hive",
+          "templeton.hive.path": "hive.tar.gz/hive/bin/hive",
+          "templeton.hive.properties": "hive.metastore.local=false,hive.metastore.uris=thrift://%HOSTGROUP::host_group_master_2%:9083,hive.metastore.sasl.enabled=false,hive.metastore.execute.setugi=true",
+          "templeton.jar": "/usr/hdp/current/hive-webhcat/share/webhcat/svr/lib/hive-webhcat-*.jar",
+          "templeton.libjars": "/usr/hdp/current/zookeeper-client/zookeeper.jar",
+          "templeton.override.enabled": "false",
+          "templeton.pig.archive": "hdfs:///hdp/apps/${hdp.version}/pig/pig.tar.gz",
+          "templeton.pig.path": "pig.tar.gz/pig/bin/pig",
+          "templeton.port": "50111",
+          "templeton.sqoop.archive": "hdfs:///hdp/apps/${hdp.version}/sqoop/sqoop.tar.gz",
+          "templeton.sqoop.home": "sqoop.tar.gz/sqoop",
+          "templeton.sqoop.path": "sqoop.tar.gz/sqoop/bin/sqoop",
+          "templeton.storage.class": "org.apache.hive.hcatalog.templeton.tool.ZooKeeperStorage",
+          "templeton.streaming.jar": "hdfs:///hdp/apps/${hdp.version}/mapreduce/hadoop-streaming.jar",
+          "templeton.zookeeper.hosts": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181"
+        }
+      }
+    },
+    {
+      "yarn-env": {
+        "properties": {
+          "apptimelineserver_heapsize": "1024",
+          "content": "\nexport HADOOP_YARN_HOME={{hadoop_yarn_home}}\nexport YARN_LOG_DIR={{yarn_log_dir_prefix}}/$USER\nexport YARN_PID_DIR={{yarn_pid_dir_prefix}}/$USER\nexport HADOOP_LIBEXEC_DIR={{hadoop_libexec_dir}}\nexport JAVA_HOME={{java64_home}}\n\n# User for YARN daemons\nexport HADOOP_YARN_USER=${HADOOP_YARN_USER:-yarn}\n\n# resolve links - $0 may be a softlink\nexport YARN_CONF_DIR=\"${YARN_CONF_DIR:-$HADOOP_YARN_HOME/conf}\"\n\n# some Java parameters\n# export JAVA_HOME=/home/y/libexec/jdk1.6.0/\nif [ \"$JAVA_HOME\" != \"\" ]; then\n  #echo \"run java in $JAVA_HOME\"\n  JAVA_HOME=$JAVA_HOME\nfi\n\nif [ \"$JAVA_HOME\" = \"\" ]; then\n  echo \"Error: JAVA_HOME is not set.\"\n  exit 1\nfi\n\nJAVA=$JAVA_HOME/bin/java\nJAVA_HEAP_MAX=-Xmx1000m\n\n# For setting YARN specific HEAP sizes please use this\n# Parameter and set appropriately\nYARN_HEAPSIZE={{yarn_heapsize}}\n\n# check envvars which might override default args\nif [ \"$YARN_HEAPSIZE\" != \"\" ]; then\n  JAVA_HEAP_MAX=\"-Xmx\"\"$YARN_HEAPSIZE\"\"m\"\nfi\n\n# Resource Manager specific parameters\n\n# Specify the max Heapsize for the ResourceManager using a numerical value\n# in the scale of MB. For example, to specify an jvm option of -Xmx1000m, set\n# the value to 1000.\n# This value will be overridden by an Xmx setting specified in either YARN_OPTS\n# and/or YARN_RESOURCEMANAGER_OPTS.\n# If not specified, the default value will be picked from either YARN_HEAPMAX\n# or JAVA_HEAP_MAX with YARN_HEAPMAX as the preferred option of the two.\nexport YARN_RESOURCEMANAGER_HEAPSIZE={{resourcemanager_heapsize}}\n\n# Specify the JVM options to be used when starting the ResourceManager.\n# These options will be appended to the options specified as YARN_OPTS\n# and therefore may override any similar flags set in YARN_OPTS\n#export YARN_RESOURCEMANAGER_OPTS=\n\n# Node Manager specific parameters\n\n# Specify the max Heapsize for the NodeManager using a numerical value\n# in the scale of MB. For example, to specify an jvm option of -Xmx1000m, set\n# the value to 1000.\n# This value will be overridden by an Xmx setting specified in either YARN_OPTS\n# and/or YARN_NODEMANAGER_OPTS.\n# If not specified, the default value will be picked from either YARN_HEAPMAX\n# or JAVA_HEAP_MAX with YARN_HEAPMAX as the preferred option of the two.\nexport YARN_NODEMANAGER_HEAPSIZE={{nodemanager_heapsize}}\n\n# Specify the max Heapsize for the HistoryManager using a numerical value\n# in the scale of MB. For example, to specify an jvm option of -Xmx1000m, set\n# the value to 1024.\n# This value will be overridden by an Xmx setting specified in either YARN_OPTS\n# and/or YARN_HISTORYSERVER_OPTS.\n# If not specified, the default value will be picked from either YARN_HEAPMAX\n# or JAVA_HEAP_MAX with YARN_HEAPMAX as the preferred option of the two.\nexport YARN_HISTORYSERVER_HEAPSIZE={{apptimelineserver_heapsize}}\n\n# Specify the JVM options to be used when starting the NodeManager.\n# These options will be appended to the options specified as YARN_OPTS\n# and therefore may override any similar flags set in YARN_OPTS\n#export YARN_NODEMANAGER_OPTS=\n\n# so that filenames w/ spaces are handled correctly in loops below\nIFS=\n\n\n# default log directory and file\nif [ \"$YARN_LOG_DIR\" = \"\" ]; then\n  YARN_LOG_DIR=\"$HADOOP_YARN_HOME/logs\"\nfi\nif [ \"$YARN_LOGFILE\" = \"\" ]; then\n  YARN_LOGFILE='yarn.log'\nfi\n\n# default policy file for service-level authorization\nif [ \"$YARN_POLICYFILE\" = \"\" ]; then\n  YARN_POLICYFILE=\"hadoop-policy.xml\"\nfi\n\n# restore ordinary behaviour\nunset IFS\n\n\nYARN_OPTS=\"$YARN_OPTS -Dhadoop.log.dir=$YARN_LOG_DIR\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.log.dir=$YARN_LOG_DIR\"\nYARN_OPTS=\"$YARN_OPTS -Dhadoop.log.file=$YARN_LOGFILE\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.log.file=$YARN_LOGFILE\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.home.dir=$YARN_COMMON_HOME\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.id.str=$YARN_IDENT_STRING\"\nYARN_OPTS=\"$YARN_OPTS -Dhadoop.root.logger=${YARN_ROOT_LOGGER:-INFO,console}\"\nYARN_OPTS=\"$YARN_OPTS -Dyarn.root.logger=${YARN_ROOT_LOGGER:-INFO,console}\"\nif [ \"x$JAVA_LIBRARY_PATH\" != \"x\" ]; then\n  YARN_OPTS=\"$YARN_OPTS -Djava.library.path=$JAVA_LIBRARY_PATH\"\nfi\nYARN_OPTS=\"$YARN_OPTS -Dyarn.policy.file=$YARN_POLICYFILE\"",
+          "min_user_id": "500",
+          "nodemanager_heapsize": "1024",
+          "resourcemanager_heapsize": "1024",
+          "yarn_heapsize": "1024",
+          "yarn_log_dir_prefix": "/var/log/hadoop-yarn",
+          "yarn_pid_dir_prefix": "/var/run/hadoop-yarn",
+          "yarn_user": "yarn"
+        }
+      }
+    },
+    {
+      "yarn-log4j": {
+        "properties": {
+          "content": "\n#Relative to Yarn Log Dir Prefix\nyarn.log.dir=.\n#\n# Job Summary Appender\n#\n# Use following logger to send summary to separate file defined by\n# hadoop.mapreduce.jobsummary.log.file rolled daily:\n# hadoop.mapreduce.jobsummary.logger=INFO,JSA\n#\nhadoop.mapreduce.jobsummary.logger=${hadoop.root.logger}\nhadoop.mapreduce.jobsummary.log.file=hadoop-mapreduce.jobsummary.log\nlog4j.appender.JSA=org.apache.log4j.DailyRollingFileAppender\n# Set the ResourceManager summary log filename\nyarn.server.resourcemanager.appsummary.log.file=hadoop-mapreduce.jobsummary.log\n# Set the ResourceManager summary log level and appender\nyarn.server.resourcemanager.appsummary.logger=${hadoop.root.logger}\n#yarn.server.resourcemanager.appsummary.logger=INFO,RMSUMMARY\n\n# To enable AppSummaryLogging for the RM,\n# set yarn.server.resourcemanager.appsummary.logger to\n# LEVEL,RMSUMMARY in hadoop-env.sh\n\n# Appender for ResourceManager Application Summary Log\n# Requires the following properties to be set\n#    - hadoop.log.dir (Hadoop Log directory)\n#    - yarn.server.resourcemanager.appsummary.log.file (resource manager app summary log filename)\n#    - yarn.server.resourcemanager.appsummary.logger (resource manager app summary log level and appender)\nlog4j.appender.RMSUMMARY=org.apache.log4j.RollingFileAppender\nlog4j.appender.RMSUMMARY.File=${yarn.log.dir}/${yarn.server.resourcemanager.appsummary.log.file}\nlog4j.appender.RMSUMMARY.MaxFileSize=256MB\nlog4j.appender.RMSUMMARY.MaxBackupIndex=20\nlog4j.appender.RMSUMMARY.layout=org.apache.log4j.PatternLayout\nlog4j.appender.RMSUMMARY.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n\nlog4j.appender.JSA.layout=org.apache.log4j.PatternLayout\nlog4j.appender.JSA.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n\nlog4j.appender.JSA.DatePattern=.yyyy-MM-dd\nlog4j.appender.JSA.layout=org.apache.log4j.PatternLayout\nlog4j.logger.org.apache.hadoop.yarn.server.resourcemanager.RMAppManager$ApplicationSummary=${yarn.server.resourcemanager.appsummary.logger}\nlog4j.additivity.org.apache.hadoop.yarn.server.resourcemanager.RMAppManager$ApplicationSummary=false"
+        }
+      }
+    },
+    {
+      "yarn-site": {
+        "properties": {
+          "hadoop.registry.rm.enabled": "true",
+          "hadoop.registry.zk.quorum": "%HOSTGROUP::host_group_master_1%:2181,%HOSTGROUP::host_group_master_3%:2181,%HOSTGROUP::host_group_master_2%:2181",
+          "yarn.acl.enable": "false",
+          "yarn.admin.acl": "",
+          "yarn.application.classpath": "$HADOOP_CONF_DIR,/usr/hdp/current/hadoop-client/*,/usr/hdp/current/hadoop-client/lib/*,/usr/hdp/current/hadoop-hdfs-client/*,/usr/hdp/current/hadoop-hdfs-client/lib/*,/usr/hdp/current/hadoop-yarn-client/*,/usr/hdp/current/hadoop-yarn-client/lib/*",
+          "yarn.client.nodemanager-connect.max-wait-ms": "60000",
+          "yarn.client.nodemanager-connect.retry-interval-ms": "10000",
+          "yarn.http.policy": "HTTP_ONLY",
+          "yarn.log-aggregation-enable": "true",
+          "yarn.log-aggregation.retain-seconds": "2592000",
+          "yarn.log.server.url": "http://%HOSTGROUP::host_group_master_1%:19888/jobhistory/logs",
+          "yarn.node-labels.fs-store.retry-policy-spec": "2000, 500",
+          "yarn.node-labels.fs-store.root-dir": "/system/yarn/node-labels",
+          "yarn.node-labels.manager-class": "org.apache.hadoop.yarn.server.resourcemanager.nodelabels.MemoryRMNodeLabelsManager",
+          "yarn.nodemanager.address": "0.0.0.0:45454",
+          "yarn.nodemanager.admin-env": "MALLOC_ARENA_MAX=$MALLOC_ARENA_MAX",
+          "yarn.nodemanager.aux-services": "mapreduce_shuffle",
+          "yarn.nodemanager.aux-services.mapreduce_shuffle.class": "org.apache.hadoop.mapred.ShuffleHandler",
+          "yarn.nodemanager.bind-host": "0.0.0.0",
+          "yarn.nodemanager.container-executor.class": "org.apache.hadoop.yarn.server.nodemanager.DefaultContainerExecutor",
+          "yarn.nodemanager.container-monitor.interval-ms": "3000",
+          "yarn.nodemanager.delete.debug-delay-sec": "0",
+          "yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage": "90",
+          "yarn.nodemanager.disk-health-checker.min-free-space-per-disk-mb": "1000",
+          "yarn.nodemanager.disk-health-checker.min-healthy-disks": "0.25",
+          "yarn.nodemanager.health-checker.interval-ms": "135000",
+          "yarn.nodemanager.health-checker.script.timeout-ms": "60000",
+          "yarn.nodemanager.linux-container-executor.cgroups.hierarchy": "hadoop-yarn",
+          "yarn.nodemanager.linux-container-executor.cgroups.mount": "false",
+          "yarn.nodemanager.linux-container-executor.cgroups.strict-resource-usage": "false",
+          "yarn.nodemanager.linux-container-executor.group": "hadoop",
+          "yarn.nodemanager.linux-container-executor.resources-handler.class": "org.apache.hadoop.yarn.server.nodemanager.util.DefaultLCEResourcesHandler",
+          "yarn.nodemanager.local-dirs": "/mnt/hadoop/yarn/local",
+          "yarn.nodemanager.log-aggregation.compression-type": "gz",
+          "yarn.nodemanager.log-aggregation.debug-enabled": "false",
+          "yarn.nodemanager.log-aggregation.num-log-files-per-app": "30",
+          "yarn.nodemanager.log-aggregation.roll-monitoring-interval-seconds": "-1",
+          "yarn.nodemanager.log-dirs": "/mnt/hadoop/yarn/log",
+          "yarn.nodemanager.log.retain-second": "604800",
+          "yarn.nodemanager.recovery.dir": "{{yarn_log_dir_prefix}}/nodemanager/recovery-state",
+          "yarn.nodemanager.recovery.enabled": "true",
+          "yarn.nodemanager.remote-app-log-dir": "/app-logs",
+          "yarn.nodemanager.remote-app-log-dir-suffix": "logs",
+          "yarn.nodemanager.resource.cpu-vcores": "1",
+          "yarn.nodemanager.resource.memory-mb": "2048",
+          "yarn.nodemanager.resource.percentage-physical-cpu-limit": "100",
+          "yarn.nodemanager.vmem-check-enabled": "false",
+          "yarn.nodemanager.vmem-pmem-ratio": "2.1",
+          "yarn.resourcemanager.address": "%HOSTGROUP::host_group_master_2%:8050",
+          "yarn.resourcemanager.admin.address": "%HOSTGROUP::host_group_master_2%:8141",
+          "yarn.resourcemanager.am.max-attempts": "2",
+          "yarn.resourcemanager.bind-host": "0.0.0.0",
+          "yarn.resourcemanager.connect.max-wait.ms": "900000",
+          "yarn.resourcemanager.connect.retry-interval.ms": "30000",
+          "yarn.resourcemanager.fs.state-store.retry-policy-spec": "2000, 500",
+          "yarn.resourcemanager.fs.state-store.uri": " ",
+          "yarn.resourcemanager.ha.enabled": "false",
+          "yarn.resourcemanager.hostname": "%HOSTGROUP::host_group_master_2%",
+          "yarn.resourcemanager.nodes.exclude-path": "/etc/hadoop/conf/yarn.exclude",
+          "yarn.resourcemanager.recovery.enabled": "true",
+          "yarn.resourcemanager.resource-tracker.address": "%HOSTGROUP::host_group_master_2%:8025",
+          "yarn.resourcemanager.scheduler.address": "%HOSTGROUP::host_group_master_2%:8030",
+          "yarn.resourcemanager.scheduler.class": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler",
+          "yarn.resourcemanager.state-store.max-completed-applications": "${yarn.resourcemanager.max-completed-applications}",
+          "yarn.resourcemanager.store.class": "org.apache.hadoop.yarn.server.resourcemanager.recovery.ZKRMStateStore",
+          "yarn.resourcemanager.system-metrics-publisher.dispatcher.pool-size": "10",
+          "yarn.resourcemanager.system-metrics-publisher.enabled": "true",
+          "yarn.resourcemanager.webapp.address": "%HOSTGROUP::host_group_master_2%:8088",
+          "yarn.resourcemanager.webapp.delegation-token-auth-filter.enabled": "false",
+          "yarn.resourcemanager.webapp.https.address": "%HOSTGROUP::host_group_master_2%:8090",
+          "yarn.resourcemanager.work-preserving-recovery.enabled": "true",
+          "yarn.resourcemanager.work-preserving-recovery.scheduling-wait-ms": "10000",
+          "yarn.resourcemanager.zk-acl": "world:anyone:rwcda",
+          "yarn.resourcemanager.zk-num-retries": "1000",
+          "yarn.resourcemanager.zk-retry-interval-ms": "1000",
+          "yarn.resourcemanager.zk-state-store.parent-path": "/rmstore",
+          "yarn.resourcemanager.zk-timeout-ms": "10000",
+          "yarn.scheduler.maximum-allocation-mb": "2048",
+          "yarn.scheduler.minimum-allocation-mb": "682",
+          "yarn.timeline-service.address": "%HOSTGROUP::host_group_master_3%:10200",
+          "yarn.timeline-service.bind-host": "0.0.0.0",
+          "yarn.timeline-service.client.max-retries": "30",
+          "yarn.timeline-service.client.retry-interval-ms": "1000",
+          "yarn.timeline-service.enabled": "true",
+          "yarn.timeline-service.generic-application-history.store-class": "org.apache.hadoop.yarn.server.applicationhistoryservice.NullApplicationHistoryStore",
+          "yarn.timeline-service.http-authentication.simple.anonymous.allowed": "true",
+          "yarn.timeline-service.http-authentication.type": "simple",
+          "yarn.timeline-service.leveldb-timeline-store.path": "/mnt/hadoop/yarn/timeline",
+          "yarn.timeline-service.leveldb-timeline-store.read-cache-size": "104857600",
+          "yarn.timeline-service.leveldb-timeline-store.start-time-read-cache-size": "10000",
+          "yarn.timeline-service.leveldb-timeline-store.start-time-write-cache-size": "10000",
+          "yarn.timeline-service.leveldb-timeline-store.ttl-interval-ms": "300000",
+          "yarn.timeline-service.store-class": "org.apache.hadoop.yarn.server.timeline.LeveldbTimelineStore",
+          "yarn.timeline-service.ttl-enable": "true",
+          "yarn.timeline-service.ttl-ms": "2678400000",
+          "yarn.timeline-service.webapp.address": "%HOSTGROUP::host_group_master_3%:8188",
+          "yarn.timeline-service.webapp.https.address": "%HOSTGROUP::host_group_master_3%:8190"
+        }
+      }
+    },
+    {
+      "zoo.cfg": {
+        "properties": {
+          "autopurge.purgeInterval": "24",
+          "autopurge.snapRetainCount": "30",
+          "clientPort": "2181",
+          "dataDir": "/mnt/hadoop/zookeeper",
+          "initLimit": "10",
+          "syncLimit": "5",
+          "tickTime": "2000"
+        }
+      }
+    },
+    {
+      "zookeeper-env": {
+        "properties": {
+          "content": "\nexport JAVA_HOME={{java64_home}}\nexport ZOOKEEPER_HOME={{zk_home}}\nexport ZOO_LOG_DIR={{zk_log_dir}}\nexport ZOOPIDFILE={{zk_pid_file}}\nexport SERVER_JVMFLAGS={{zk_server_heapsize}}\nexport JAVA=$JAVA_HOME/bin/java\nexport CLASSPATH=$CLASSPATH:/usr/share/zookeeper/*\n\n{% if security_enabled %}\nexport SERVER_JVMFLAGS=\"$SERVER_JVMFLAGS -Djava.security.auth.login.config={{zk_server_jaas_file}}\"\nexport CLIENT_JVMFLAGS=\"$CLIENT_JVMFLAGS -Djava.security.auth.login.config={{zk_client_jaas_file}}\"\n{% endif %}",
+          "zk_log_dir": "/var/log/zookeeper",
+          "zk_pid_dir": "/var/run/zookeeper",
+          "zk_user": "zookeeper"
+        }
+      }
+    },
+    {
+      "zookeeper-log4j": {
+        "properties": {
+          "content": "\n#\n#\n# Licensed to the Apache Software Foundation (ASF) under one\n# or more contributor license agreements.  See the NOTICE file\n# distributed with this work for additional information\n# regarding copyright ownership.  The ASF licenses this file\n# to you under the Apache License, Version 2.0 (the\n# \"License\"); you may not use this file except in compliance\n# with the License.  You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing,\n# software distributed under the License is distributed on an\n# \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n# KIND, either express or implied.  See the License for the\n# specific language governing permissions and limitations\n# under the License.\n#\n#\n#\n\n#\n# ZooKeeper Logging Configuration\n#\n\n# DEFAULT: console appender only\nlog4j.rootLogger=INFO, CONSOLE\n\n# Example with rolling log file\n#log4j.rootLogger=DEBUG, CONSOLE, ROLLINGFILE\n\n# Example with rolling log file and tracing\n#log4j.rootLogger=TRACE, CONSOLE, ROLLINGFILE, TRACEFILE\n\n#\n# Log INFO level and above messages to the console\n#\nlog4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender\nlog4j.appender.CONSOLE.Threshold=INFO\nlog4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout\nlog4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n\n\n#\n# Add ROLLINGFILE to rootLogger to get log file output\n#    Log DEBUG level and above messages to a log file\nlog4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender\nlog4j.appender.ROLLINGFILE.Threshold=DEBUG\nlog4j.appender.ROLLINGFILE.File=zookeeper.log\n\n# Max log file size of 10MB\nlog4j.appender.ROLLINGFILE.MaxFileSize=10MB\n# uncomment the next line to limit number of backup files\n#log4j.appender.ROLLINGFILE.MaxBackupIndex=10\n\nlog4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout\nlog4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n\n\n\n#\n# Add TRACEFILE to rootLogger to get log file output\n#    Log DEBUG level and above messages to a log file\nlog4j.appender.TRACEFILE=org.apache.log4j.FileAppender\nlog4j.appender.TRACEFILE.Threshold=TRACE\nlog4j.appender.TRACEFILE.File=zookeeper_trace.log\n\nlog4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout\n### Notice we are including log4j's NDC here (%x)\nlog4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L][%x] - %m%n"
+        }
+      }
+    }
+  ],
+  "host_groups": [
+    {
+      "name": "host_group_slave_1",
+      "configurations": [],
+      "components": [
+        {
+          "name": "HBASE_REGIONSERVER"
+        },
+        {
+          "name": "NODEMANAGER"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "DATANODE"
+        }
+      ],
+      "cardinality": "3"
+    },
+    {
+      "name": "host_group_slave_2",
+      "configurations": [],
+      "components": [
+        {
+          "name": "KAFKA_BROKER"
+        },
+        {
+          "name": "SUPERVISOR"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        }
+      ],
+      "cardinality": "3"
+    },
+    {
+      "name": "host_group_master_3",
+      "configurations": [],
+      "components": [
+        {
+          "name": "ZOOKEEPER_SERVER"
+        },
+        {
+          "name": "APP_TIMELINE_SERVER"
+        },
+        {
+          "name": "HBASE_MASTER"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "SECONDARY_NAMENODE"
+        },
+        {
+          "name": "DRPC_SERVER"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "host_group_master_2",
+      "configurations": [],
+      "components": [
+        {
+          "name": "ZOOKEEPER_SERVER"
+        },
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        },
+        {
+          "name": "PIG"
+        },
+        {
+          "name": "STORM_UI_SERVER"
+        },
+        {
+          "name": "HIVE_SERVER"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "TEZ_CLIENT"
+        },
+        {
+          "name": "HIVE_METASTORE"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "YARN_CLIENT"
+        },
+        {
+          "name": "MAPREDUCE2_CLIENT"
+        },
+        {
+          "name": "MYSQL_SERVER"
+        },
+        {
+          "name": "NIMBUS"
+        },
+        {
+          "name": "RESOURCEMANAGER"
+        },
+        {
+          "name": "WEBHCAT_SERVER"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "host_group_master_1",
+      "configurations": [],
+      "components": [
+        {
+          "name": "ZOOKEEPER_SERVER"
+        },
+        {
+          "name": "HISTORYSERVER"
+        },
+        {
+          "name": "OOZIE_CLIENT"
+        },
+        {
+          "name": "NAMENODE"
+        },
+        {
+          "name": "OOZIE_SERVER"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "YARN_CLIENT"
+        },
+        {
+          "name": "FALCON_SERVER"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "MAPREDUCE2_CLIENT"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "host_group_client_1",
+      "configurations": [],
+      "components": [
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        },
+        {
+          "name": "PIG"
+        },
+        {
+          "name": "OOZIE_CLIENT"
+        },
+        {
+          "name": "HBASE_CLIENT"
+        },
+        {
+          "name": "HCAT"
+        },
+        {
+          "name": "KNOX_GATEWAY"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "FALCON_CLIENT"
+        },
+        {
+          "name": "TEZ_CLIENT"
+        },
+        {
+          "name": "SLIDER"
+        },
+        {
+          "name": "SQOOP"
+        },
+        {
+          "name": "HDFS_CLIENT"
+        },
+        {
+          "name": "HIVE_CLIENT"
+        },
+        {
+          "name": "YARN_CLIENT"
+        },
+        {
+          "name": "METRICS_COLLECTOR"
+        },
+        {
+          "name": "FLUME_HANDLER"
+        },
+        {
+          "name": "MAPREDUCE2_CLIENT"
+        }
+      ],
+      "cardinality": "1"
+    }
+  ],
+  "Blueprints": {
+    "blueprint_name": "hdp-streaming-cluster",
+    "stack_name": "HDP",
+    "stack_version": "2.2"
+  }
+}

--- a/src/test/resources/multi-node-hdfs-yarn-heterogen-config.json
+++ b/src/test/resources/multi-node-hdfs-yarn-heterogen-config.json
@@ -7,17 +7,23 @@
   "configurations": [
     {
       "global": {
-        "nagios_contact": "admin@localhost"
+        "properties": {
+          "nagios_contact": "admin@localhost"
+        }
       }
     },
     {
       "hdfs-site": {
-        "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     },
     {
       "yarn-site": {
-        "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     }
   ],

--- a/src/test/resources/multi-node-hdfs-yarn-heterogen-master-slave-config.json
+++ b/src/test/resources/multi-node-hdfs-yarn-heterogen-master-slave-config.json
@@ -7,17 +7,23 @@
   "configurations": [
     {
       "global": {
-        "nagios_contact": "admin@localhost"
+        "properties": {
+          "nagios_contact": "admin@localhost"
+        }
       }
     },
     {
       "hdfs-site": {
-        "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     },
     {
       "yarn-site": {
-        "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     }
   ],

--- a/src/test/resources/multi-node-hdfs-yarn-heterogen-with-config-result.json
+++ b/src/test/resources/multi-node-hdfs-yarn-heterogen-with-config-result.json
@@ -7,17 +7,23 @@
   "configurations": [
     {
       "global": {
-        "nagios_contact": "admin@localhost"
+        "properties": {
+          "nagios_contact": "admin@localhost"
+        }
       }
     },
     {
       "hdfs-site": {
-        "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     },
     {
       "yarn-site": {
-        "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     }
   ],

--- a/src/test/resources/multi-node-hdfs-yarn-heterogen-with-config.json
+++ b/src/test/resources/multi-node-hdfs-yarn-heterogen-with-config.json
@@ -7,17 +7,23 @@
   "configurations": [
     {
       "global": {
-        "nagios_contact": "admin@localhost"
+        "properties": {
+          "nagios_contact": "admin@localhost"
+        }
       }
     },
     {
       "hdfs-site": {
-        "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     },
     {
       "yarn-site": {
-        "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     }
   ],

--- a/src/test/resources/multi-node-hdfs-yarn-heterogen-with-multi-config.json
+++ b/src/test/resources/multi-node-hdfs-yarn-heterogen-with-multi-config.json
@@ -1,4 +1,9 @@
 {
+  "Blueprints": {
+    "blueprint_name": "multi-node-hdfs-yarn",
+    "stack_version": "2.1",
+    "stack_name": "HDP"
+  },
   "configurations": [
     {
       "global": {
@@ -23,16 +28,29 @@
       }
     },
     {
-          "core-site": {
-            "properties": {
-              "fs.defaultFS": "localhost:9000"
-            }
-          }
+      "core-site": {
+        "properties": {
+          "fs.defaultFS": "localhost:9000"
         }
+      }
+    }
   ],
   "host_groups": [
     {
       "name": "master",
+      "configurations": [
+        {
+          "hdfs-site": {
+            "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+          }
+        },
+        {
+          "yarn-site": {
+            "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/",
+            "property-key": "property-value"
+          }
+        }
+      ],
       "components": [
         {
           "name": "NAMENODE"
@@ -63,6 +81,19 @@
     },
     {
       "name": "slave_1",
+      "configurations": [
+        {
+          "yarn-site": {
+            "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/",
+            "property-key": "property-value"
+          }
+        },
+        {
+          "hdfs-site": {
+            "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+          }
+        }
+      ],
       "components": [
         {
           "name": "DATANODE"
@@ -88,10 +119,5 @@
       ],
       "cardinality": "2"
     }
-  ],
-  "Blueprints": {
-    "blueprint_name": "multi-node-hdfs-yarn",
-    "stack_name": "HDP",
-    "stack_version": "2.1"
-  }
+  ]
 }

--- a/src/test/resources/multi-node-hdfs-yarn-heterogen.json
+++ b/src/test/resources/multi-node-hdfs-yarn-heterogen.json
@@ -2,17 +2,23 @@
   "configurations": [
     {
       "global": {
-        "nagios_contact": "admin@localhost"
+        "properties": {
+          "nagios_contact": "admin@localhost"
+        }
       }
     },
     {
       "hdfs-site": {
-        "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     },
     {
       "yarn-site": {
-        "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     }
   ],

--- a/src/test/resources/multi-node-hdfs-yarn.json
+++ b/src/test/resources/multi-node-hdfs-yarn.json
@@ -2,17 +2,23 @@
   "configurations": [
     {
       "global": {
-        "nagios_contact": "admin@localhost"
+        "properties": {
+          "nagios_contact": "admin@localhost"
+        }
       }
     },
     {
       "hdfs-site": {
-        "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "dfs.datanode.data.dir": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     },
     {
       "yarn-site": {
-        "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        "properties": {
+          "yarn.nodemanager.local-dirs": "/mnt/fs1/,/mnt/fs2/"
+        }
       }
     }
   ],


### PR DESCRIPTION
In Cloudbreak we need to add/override both global and host group level configurations as well thus the 2 addBlueprint method which takes configuration has been removed and the extend blueprint configuration methods has been modified to public. This results that the clients need to invoke 2 methods at least if they want to override some configurations like:
```java
ambariClient.extendBlueprintHostGroupConfiguration(blueprintText, hostGroupConfig);
ambariClient.extendBlueprintGlobalConfiguration(blueprintText, globalConfig);
ambariClient.addBlueprint(blueprintText);
```
Global configuration properties are moved to a map **properties** as prior to Ambari 2.1

@schfeca75 @akanto 