### PR TITLE
Add Ambari Metrics Service to blueprints

### DIFF
--- a/src/main/resources/blueprints/multi-node-hdfs-yarn
+++ b/src/main/resources/blueprints/multi-node-hdfs-yarn
@@ -59,6 +59,6 @@
   "Blueprints": {
     "blueprint_name": "multi-node-hdfs-yarn",
     "stack_name": "HDP",
-    "stack_version": "2.2"
+    "stack_version": "2.3"
   }
 }

--- a/src/main/resources/blueprints/multi-node-hive
+++ b/src/main/resources/blueprints/multi-node-hive
@@ -1,14 +1,15 @@
 {
   "host_groups": [
     {
-      "name": "master",
+      "name": "master_1",
       "components": [
         {
           "name": "NAMENODE"
         },
         {
-          "name": "SECONDARY_NAMENODE"
+          "name" : "HIVE_SERVER"
         },
+
         {
           "name": "RESOURCEMANAGER"
         },
@@ -22,17 +23,65 @@
           "name": "ZOOKEEPER_SERVER"
         }, 
         {
+          "name" : "METRICS_MONITOR"
+        },
+        {
+          "name" : "WEBHCAT_SERVER"
+        },
+        {
+          "name" : "TEZ_CLIENT"
+        },
+        {
+          "name" : "HIVE_CLIENT"
+        },
+        {
+          "name" : "PIG"
+        }
+        ],
+      "cardinality": "1"
+    },
+        {
+      "name": "master_2",
+      "components": [
+        {
+          "name": "SECONDARY_NAMENODE"
+        },
+        {
+          "name" : "HIVE_SERVER"
+        }, 
+        {
           "name" : "METRICS_COLLECTOR"
         },
         {
           "name" : "METRICS_MONITOR"
+        },
+        {
+          "name" : "HCAT"
+        },
+        {
+          "name" : "TEZ_CLIENT"
+        },
+        {
+          "name" : "HIVE_METASTORE"
+        },
+        {
+          "name" : "MYSQL_SERVER"
+        },
+        {
+          "name" : "HIVE_CLIENT"
+        },
+        {
+          "name" : "PIG"
         }
-    ],
+      ],
       "cardinality": "1"
     },
     {
       "name": "slave_1",
       "components": [
+        {
+          "name" : "PIG"
+        },
         {
           "name": "DATANODE"
         },
@@ -53,13 +102,20 @@
         },
         {
           "name" : "METRICS_MONITOR"
+        },
+        {
+          "name" : "TEZ_CLIENT"
+        },
+        {
+          "name" : "HIVE_CLIENT"
         }
+
       ],
       "cardinality": "1+"
     }
   ],
   "Blueprints": {
-    "blueprint_name": "multi-node-hdfs-yarn",
+    "blueprint_name": "multi-node-hive",
     "stack_name": "HDP",
     "stack_version": "2.3"
   }

--- a/src/main/resources/blueprints/single-node-hdfs-yarn
+++ b/src/main/resources/blueprints/single-node-hdfs-yarn
@@ -38,6 +38,12 @@
       },
       {
         "name" : "ZOOKEEPER_CLIENT"
+      },
+      {
+        "name" : "METRICS_COLLECTOR"
+      },
+      {
+        "name" : "METRICS_MONITOR
       }
       ],
       "cardinality" : "1"

--- a/src/main/resources/blueprints/single-node-hdfs-yarn
+++ b/src/main/resources/blueprints/single-node-hdfs-yarn
@@ -46,6 +46,6 @@
   "Blueprints" : {
     "blueprint_name" : "single-node-hdfs-yarn",
     "stack_name" : "HDP",
-    "stack_version" : "2.2"
+    "stack_version" : "2.3"
   }
 }


### PR DESCRIPTION
Added AMS to multi-node-yarn and single-node-yarn blueprints and removed the Ganglia email address from the multi-node-yarn blueprint.